### PR TITLE
spec: orphan container cleanup config

### DIFF
--- a/openspec/changes/add-orphan-cleanup-config/proposal.md
+++ b/openspec/changes/add-orphan-cleanup-config/proposal.md
@@ -1,0 +1,29 @@
+# Change: Orphan Container Cleanup Configuration
+
+## Why
+
+When a service is removed from a Bosun-managed compose template, `docker compose up -d` alone does not stop the old container. The deleted service becomes an orphan: still running, still consuming resources, invisible to GitOps. Docker Compose natively supports `--remove-orphans` to handle this, and Bosun already passes the flag unconditionally in all compose-up call sites. However, there is no way to disable it. In shared or cautious environments (e.g., services managed by multiple tools on the same Docker host), unconditional orphan removal can destroy containers that Bosun does not own. Making this configurable lets operators opt out when the flag would be destructive.
+
+## What Changes
+
+- Add `remove_orphans` field to `bosun.yaml` config (default: `true`, preserving current behavior)
+- Add `BOSUN_REMOVE_ORPHANS` environment variable (overrides config file)
+- Add `RemoveOrphans` field to `DeployOps` struct
+- Conditionally append `--remove-orphans` to compose-up args based on the config value
+- Update all compose-up call sites in the reconciler: `ComposeUpMultiple`, rollback path in `ComposeUpMultipleWithRollback`, and `ComposeUpRemote`
+
+## Impact
+
+- Affected specs: `reconcile`
+- Affected code:
+  - `internal/config/config.go` — new `remove_orphans` YAML field, getter, extraction
+  - `internal/reconcile/deploy.go` — conditional `--remove-orphans` in `ComposeUpMultiple`, `ComposeUpMultipleWithRollback`, `ComposeUpRemote`
+  - `internal/reconcile/reconcile.go` — pass config to `DeployOps`
+  - `internal/cmd/emergency.go` — `runComposeUp()` in mayday restore (standalone, not reconciler-managed; keeps hardcoded `--remove-orphans` because emergency restore should always clean up)
+- All consumers:
+  - `deploy.go:875` — `ComposeUpMultiple` appends `--remove-orphans` unconditionally
+  - `deploy.go:972` — rollback path in `ComposeUpMultipleWithRollback` appends `--remove-orphans` unconditionally
+  - `deploy.go:1047` — `ComposeUpRemote` SSH command includes `--remove-orphans` unconditionally
+  - `emergency.go:730` — `runComposeUp()` in mayday restore (standalone helper, not part of reconciler; intentionally unchanged)
+  - `config.go:112` — comment referencing `--remove-orphans` on `ProjectName`
+  - `provision.go:215` — comment referencing `--remove-orphans` on project name

--- a/openspec/changes/add-orphan-cleanup-config/specs/reconcile/spec.md
+++ b/openspec/changes/add-orphan-cleanup-config/specs/reconcile/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: Orphan Container Cleanup Configuration
+
+The reconciler SHALL support a configurable `remove_orphans` option (default: `true`)
+that controls whether `--remove-orphans` is passed to `docker compose up` commands.
+
+When `remove_orphans` is `true`, the reconciler SHALL append `--remove-orphans` to
+all compose-up invocations (local, rollback, and remote). This removes containers
+belonging to services that have been deleted from the compose file.
+
+When `remove_orphans` is `false`, the reconciler SHALL omit `--remove-orphans` from
+compose-up invocations, leaving orphan containers running.
+
+The option SHALL be configurable via `bosun.yaml` (`remove_orphans` field) and the
+`BOSUN_REMOVE_ORPHANS` environment variable. The environment variable SHALL take
+precedence over the config file value.
+
+#### Scenario: Default behavior removes orphans
+
+- **WHEN** no `remove_orphans` config is set
+- **AND** a service is removed from the compose template
+- **AND** the reconciler runs `docker compose up`
+- **THEN** the command includes `--remove-orphans`
+- **AND** the container from the removed service is stopped and removed
+
+#### Scenario: Orphan removal disabled via config file
+
+- **WHEN** `remove_orphans: false` is set in `bosun.yaml`
+- **AND** a service is removed from the compose template
+- **AND** the reconciler runs `docker compose up`
+- **THEN** the command does NOT include `--remove-orphans`
+- **AND** the container from the removed service continues running
+
+#### Scenario: Environment variable overrides config file
+
+- **WHEN** `remove_orphans: true` is set in `bosun.yaml`
+- **AND** `BOSUN_REMOVE_ORPHANS=false` is set in the environment
+- **THEN** the reconciler omits `--remove-orphans` from compose-up commands
+
+#### Scenario: Rollback respects orphan cleanup config
+
+- **WHEN** `remove_orphans` is `false`
+- **AND** a compose-up fails and rollback executes
+- **THEN** the rollback compose-up also omits `--remove-orphans`
+
+#### Scenario: Remote deploy respects orphan cleanup config
+
+- **WHEN** `remove_orphans` is `false`
+- **AND** a remote deployment runs compose-up over SSH
+- **THEN** the SSH command omits `--remove-orphans`
+
+## MODIFIED Requirements
+
+### Requirement: Service Orchestration
+
+The reconciler SHALL run `docker compose up -d` with a configured project name to
+bring services to their declared state. When orphan cleanup is enabled (default),
+`--remove-orphans` SHALL be appended to remove containers from deleted services.
+
+The `--wait` flag SHALL NOT be used, because it exits non-zero when any container
+is unhealthy, including pre-existing unhealthy containers unrelated to the current
+deployment. Health inspection is handled separately by post-deploy verification.
+
+Multiple compose files SHALL be supported via multiple `-f` flags.
+
+On compose up failure, the reconciler SHALL attempt rollback using the backup
+compose files. Rollback results are distinguished via sentinel errors:
+`ErrRollbackSucceeded` (deploy failed, rollback worked) and `ErrRollbackFailed`
+(both failed, critical state).
+
+A configurable `ComposeUpTimeout` (default 10 minutes) SHALL apply to compose
+operations.
+
+#### Scenario: Compose up with project name and orphan cleanup enabled
+
+- **WHEN** compose up runs with `ProjectName` set to "bosun"
+- **AND** `remove_orphans` is `true` (default)
+- **THEN** the command includes `-p bosun`
+- **AND** `--remove-orphans` cleans up containers from removed services
+
+#### Scenario: Compose up with project name and orphan cleanup disabled
+
+- **WHEN** compose up runs with `ProjectName` set to "bosun"
+- **AND** `remove_orphans` is `false`
+- **THEN** the command includes `-p bosun`
+- **AND** `--remove-orphans` is NOT included in the command
+
+#### Scenario: Deploy succeeds despite pre-existing unhealthy container
+
+- **WHEN** container A is healthy and container B was already unhealthy
+- **THEN** compose up exits 0 (no `--wait` flag)
+- **AND** post-deploy verification logs a warning for container B
+- **AND** the deployment is marked successful
+
+#### Scenario: Compose up fails with rollback
+
+- **WHEN** compose up fails
+- **AND** a backup exists with previous compose files
+- **THEN** the reconciler runs compose up with the backup files
+- **AND** returns `ErrRollbackSucceeded` if rollback works
+
+#### Scenario: Both compose up and rollback fail
+
+- **WHEN** compose up fails and rollback also fails
+- **THEN** the reconciler returns `ErrRollbackFailed`
+- **AND** logs at ERROR level indicating a critical state

--- a/openspec/changes/add-orphan-cleanup-config/tasks.md
+++ b/openspec/changes/add-orphan-cleanup-config/tasks.md
@@ -1,0 +1,30 @@
+## 1. Configuration Surface
+
+- [ ] 1.1 Add `RemoveOrphans` field (default `true`) to `configFile` struct in `internal/config/config.go`
+- [ ] 1.2 Add `removeOrphans` field to `Config` struct and `RemoveOrphans()` getter
+- [ ] 1.3 Extract `remove_orphans` in `extractConfig()` helper
+- [ ] 1.4 Write unit tests for config parsing with and without the field
+
+## 2. Environment Variable
+
+- [ ] 2.1 Parse `BOSUN_REMOVE_ORPHANS` in daemon `ConfigFromEnv()` (bool, overrides config file)
+- [ ] 2.2 Write tests for env var parsing and precedence over config file
+
+## 3. Deploy Layer
+
+- [ ] 3.1 Add `RemoveOrphans bool` field to `DeployOps` struct
+- [ ] 3.2 Update `ComposeUpMultiple` to conditionally append `--remove-orphans` based on `RemoveOrphans`
+- [ ] 3.3 Update rollback path in `ComposeUpMultipleWithRollback` to use same conditional
+- [ ] 3.4 Update `ComposeUpRemote` SSH command to conditionally include `--remove-orphans`
+- [ ] 3.5 Write tests for compose arg construction with `RemoveOrphans` true and false
+
+## 4. Reconciler Wiring
+
+- [ ] 4.1 Pass `RemoveOrphans` from reconcile config to `DeployOps` during setup
+- [ ] 4.2 Verify daemon config propagation to reconciler
+
+## 5. Documentation
+
+- [ ] 5.1 Add `BOSUN_REMOVE_ORPHANS` to AGENTS.md env var table
+- [ ] 5.2 Update `skills/onboard/resources/configuration.md` with `remove_orphans` field
+- [ ] 5.3 Update `skills/onboard/resources/gitops.md` with orphan cleanup behavior


### PR DESCRIPTION
## Summary

- Adds OpenSpec change proposal for making `--remove-orphans` configurable in Bosun's reconciler
- `--remove-orphans` is already hardcoded in all compose-up call sites; this proposal adds a `remove_orphans` config field (default `true`) and `BOSUN_REMOVE_ORPHANS` env var to allow operators to opt out
- Includes MODIFIED delta for the existing Service Orchestration requirement and ADDED delta for the new Orphan Container Cleanup Configuration requirement

Closes #75

## Test plan

- [x] `openspec validate add-orphan-cleanup-config --strict` passes
- [ ] Review proposal.md for accurate consumer grep
- [ ] Review delta spec scenarios for completeness
- [ ] Review tasks.md for implementation coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable orphan container cleanup feature with a new `remove_orphans` option in bosun.yaml (enabled by default)
  * Added `BOSUN_REMOVE_ORPHANS` environment variable to override configuration at runtime
  * The setting now applies to deployment and rollback operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->