### PR TITLE
feat(openspec): formalize spec review workflow with Stage 1.5 gate

### DIFF
--- a/.github/workflows/spec-review.yml
+++ b/.github/workflows/spec-review.yml
@@ -1,0 +1,56 @@
+name: Spec Review Gate
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  ready-to-build:
+    name: Spec PR Review Gate
+    if: startsWith(github.head_ref, 'spec/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check ready-to-build label
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$PR_LABELS" | grep -q '"ready-to-build"'; then
+            echo "Spec PR has ready-to-build label -- review complete"
+          else
+            echo "::error::Spec PR is missing the ready-to-build label."
+            echo ""
+            echo "Spec PRs must pass CodeRabbit review before merge."
+            echo "Run /spec-review to iterate on findings and apply the label."
+            echo ""
+            echo "See openspec/AGENTS.md Stage 1.5 for the full workflow."
+            exit 1
+          fi
+
+  validate-spec:
+    name: Validate Spec
+    if: startsWith(github.head_ref, 'spec/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install OpenSpec
+        run: npm install -g openspec-cli
+
+      - name: Extract change ID from branch
+        id: change-id
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          CHANGE_ID="${BRANCH#spec/}"
+          echo "id=$CHANGE_ID" >> "$GITHUB_OUTPUT"
+          echo "Validating change: $CHANGE_ID"
+
+      - name: Validate spec
+        env:
+          CHANGE_ID: ${{ steps.change-id.outputs.id }}
+        run: openspec validate "$CHANGE_ID" --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,19 @@ Common file operations (copy, ensure directory, atomic write).
 
 When a feature adds or changes behavior covered by `openspec/specs/`, **MUST** create a change proposal under `openspec/changes/<id>/` with spec deltas BEFORE writing implementation code. Plan mode plans inform the proposal but do not replace it. See `openspec/AGENTS.md` for the full workflow.
 
+## Spec Review Workflow
+
+Spec PRs follow an iterative review cycle before implementation begins:
+
+1. **Open PR** from spec branch (`spec/<change-id>`) targeting `main`
+2. **CodeRabbit reviews** automatically on push
+3. **Fix all findings** — including nitpicks (consistency prevents implementation bugs)
+4. **Iterate** until convergence (0 actionable or only stale findings)
+5. **Label `ready-to-build`** — spec is stable, implementation can begin
+6. **Rate-limit handling**: If CodeRabbit doesn't review within ~5min, trigger manually with `@coderabbitai review`
+
+The `ready-to-build` label is a gate: do not start implementation until it's applied. Use `/spec-review` to automate the cycle.
+
 ## Adding a New Command
 
 1. Create file in `internal/cmd/<name>.go`

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -10,7 +10,9 @@ Instructions for AI coding assistants using OpenSpec for spec-driven development
 - Scaffold: `proposal.md`, `tasks.md`, `design.md` (only if needed), and delta specs per affected capability
 - Write deltas: use `## ADDED|MODIFIED|REMOVED|RENAMED Requirements`; include at least one `#### Scenario:` per requirement
 - Validate: `openspec validate [change-id] --strict` and fix issues
-- Request approval: Do not start implementation until proposal is approved
+- Open spec PR: push branch, open PR targeting `main`, iterate on CodeRabbit review
+- Label `ready-to-build`: spec is stable, implementation can begin
+- Request approval: Do not start implementation until proposal is approved and PR is labeled
 
 ## Three-Stage Workflow
 
@@ -46,6 +48,21 @@ Skip proposal for:
 3. Draft spec deltas using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement.
 4. Run `openspec validate <id> --strict` and resolve any issues before sharing the proposal.
 
+### Stage 1.5: Spec Review
+
+Spec PRs follow an iterative review cycle before implementation begins.
+
+1. **Open PR** from spec branch (`spec/<change-id>`) targeting `main`
+2. **CodeRabbit reviews** automatically on push
+3. **Fix all findings** — including nitpicks (consistency prevents implementation bugs)
+4. **Iterate** until convergence (0 actionable comments or only stale/repeated findings)
+5. **Label `ready-to-build`** — spec is stable, implementation can begin
+6. **Rate-limit handling**: If CodeRabbit doesn't review within ~5min, trigger manually with `@coderabbitai review`
+
+The `ready-to-build` label is a gate: do not start Stage 2 until it is applied.
+
+Use `/spec-review` to automate the check/fix/iterate/label cycle across open spec PRs.
+
 ### Stage 2: Implementing Changes
 Track these steps as TODOs and complete them one by one.
 1. **Read proposal.md** - Understand what's being built
@@ -54,7 +71,7 @@ Track these steps as TODOs and complete them one by one.
 4. **Implement tasks sequentially** - Complete in order
 5. **Confirm completion** - Ensure every item in `tasks.md` is finished before updating statuses
 6. **Update checklist** - After all work is done, set every task to `- [x]` so the list reflects reality
-7. **Approval gate** - Do not start implementation until the proposal is reviewed and approved
+7. **Approval gate** - Do not start implementation until the spec PR carries `ready-to-build` (see Stage 1.5)
 
 ### Stage 3: Archiving Changes
 After deployment, create separate PR to:

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: spec-review
+description: "Iterate on CodeRabbit spec PR reviews until convergence, then label ready-to-build"
+---
+
+Automate the spec review cycle for open spec PRs. Fetch CodeRabbit findings, fix issues, iterate until convergence, and label PRs `ready-to-build`.
+
+## Workflow
+
+### 1. Discover Spec PRs
+
+If PR numbers were provided as arguments, use those. Otherwise, find all open PRs matching `spec/*` branches:
+
+```bash
+gh pr list --state open --head "spec/" --json number,headRefName,title,labels,updatedAt
+```
+
+If no spec PRs are found, report that and stop.
+
+### 2. For Each PR — Assess Review Status
+
+For each spec PR, gather:
+
+- **CodeRabbit review status**: Check PR reviews and inline comments
+- **Actionable comment count**: Comments that are not resolved or outdated
+- **Last review timestamp**: When CodeRabbit last reviewed
+- **Current labels**: Whether `ready-to-build` is already applied
+
+```bash
+# Get PR reviews
+gh pr view <number> --json reviews,comments,labels,headRefName
+
+# Get inline review comments with file paths
+gh api repos/{owner}/{repo}/pulls/<number>/comments --jq '.[] | {path: .path, body: .body, line: .line, created_at: .created_at, in_reply_to_id: .in_reply_to_id}'
+```
+
+### 3. Present Summary
+
+Display a summary table showing the status of each spec PR:
+
+| PR | Branch | Title | Actionable | Last Review | Status |
+|----|--------|-------|------------|-------------|--------|
+| #42 | spec/add-alerts | Add alert providers | 3 | 2h ago | Needs fixes |
+| #43 | spec/update-drift | Update drift detection | 0 | 1h ago | Converged |
+
+### 4. Fix Findings
+
+For PRs with actionable findings, offer to dispatch worktree-isolated agents (one per PR) to:
+
+1. Check out the spec branch in a worktree
+2. Read each CodeRabbit comment with file path and suggested fix
+3. Apply fixes to the spec files
+4. Commit and push the fixes
+
+Use the Agent tool with `isolation: "worktree"` to prevent cross-PR conflicts.
+
+After fixes are pushed, CodeRabbit will automatically re-review. Wait ~5 minutes for the review. If no review appears, suggest triggering manually:
+
+```bash
+gh pr comment <number> --body "@coderabbitai review"
+```
+
+### 5. Iterate
+
+Re-run the assessment (step 2) after each fix round. Continue until:
+
+- **Converged**: 0 actionable comments, or only stale/repeated findings
+- **Stalled**: Same findings persist after 2 fix rounds (escalate to user)
+
+### 6. Label `ready-to-build`
+
+When a PR converges, apply the label:
+
+```bash
+gh pr edit <number> --add-label "ready-to-build"
+```
+
+Report final status for all PRs.
+
+## Convergence Criteria
+
+A spec PR is converged when ANY of:
+
+- CodeRabbit leaves 0 new comments on the latest push
+- All remaining comments are resolved or are repeats of previously addressed findings
+- The review summary shows no actionable items
+
+## Rate Limiting
+
+CodeRabbit may rate-limit reviews on rapid successive pushes. If a review doesn't appear within ~5 minutes after a push:
+
+1. Check if the PR has a pending review status
+2. Trigger manually with `@coderabbitai review` as a PR comment
+3. Wait another 5 minutes before escalating
+
+## Usage Examples
+
+```bash
+# Review all open spec PRs
+/spec-review
+
+# Review specific PRs
+/spec-review 42 43
+
+# Review a single PR
+/spec-review 42
+```


### PR DESCRIPTION
## Summary

- Add **Stage 1.5: Spec Review** to `openspec/AGENTS.md` between spec creation (Stage 1) and implementation (Stage 2)
- Add **Spec Review Workflow** section to `AGENTS.md` documenting the iterative review cycle
- Create `/spec-review` skill that automates the check/fix/iterate/label cycle for spec PRs
- Add **spec-review.yml** GitHub Actions workflow enforcing `ready-to-build` label gate + `openspec validate --strict`

Codifies the iterative CodeRabbit review workflow that emerged organically across 5 spec PR rounds. The `ready-to-build` label acts as a state machine transition: spec PRs cannot proceed to implementation until they pass review.

## Test plan

- [ ] Verify `openspec/AGENTS.md` reads clearly with new Stage 1.5 between Stage 1 and Stage 2
- [ ] Verify `AGENTS.md` Spec Review Workflow section is positioned after Spec Before Code
- [ ] Verify `/spec-review` skill file has correct frontmatter and workflow steps
- [ ] Verify `.github/workflows/spec-review.yml` only triggers on `spec/*` branch PRs
- [ ] Verify workflow uses safe env var patterns (no direct `${{ github.head_ref }}` in `run:`)
- [ ] Verify `ready-to-build` label check fails when label is missing
- [ ] Verify `openspec validate` step extracts change-id correctly from branch name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an automated spec review workflow with quality gates for specification pull requests.
  * Added a "ready-to-build" label requirement to control progression through the review process.
  * Integrated automated validation for spec changes using strict compliance checks.

* **Documentation**
  * Added comprehensive workflow documentation for the new spec review process and procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->