### PR TITLE
test(manifest): add spaced template flags test for commandList

### DIFF
--- a/internal/cmd/upgrade_test.go
+++ b/internal/cmd/upgrade_test.go
@@ -505,6 +505,11 @@ func TestCommandList(t *testing.T) {
 			command:  []any{},
 			expected: nil,
 		},
+		{
+			name:     "scalar command with spaced template flags",
+			command:  "--providers.docker.defaultRule=Host(`{{ .subdomain }}.{{ .domain }}`)",
+			expected: []string{"--providers.docker.defaultRule=Host(`{{", ".subdomain", "}}.{{", ".domain", "}}`)"}, // strings.Fields splits on spaces
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
- Add table-driven subtest documenting how `commandList()` splits scalar commands containing spaced template flags via `strings.Fields()`
- Documents the edge case where a defaultRule with Go template syntax gets split into multiple tokens

Closes #bosun-4b7

## Test plan
- [x] New test passes
- [x] Full test suite passes
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)