### PR TITLE
feat(docker): add graceful container shutdown with configurable timeout

### DIFF
--- a/internal/cmd/crew.go
+++ b/internal/cmd/crew.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cameronsjo/bosun/internal/config"
 	"github.com/cameronsjo/bosun/internal/docker"
 	"github.com/cameronsjo/bosun/internal/log"
 	"github.com/cameronsjo/bosun/internal/ui"
@@ -177,14 +178,21 @@ var crewRestartCmd = &cobra.Command{
 		name := args[0]
 
 		return withDockerClient(func(ctx context.Context, client *docker.Client) error {
+			// Load config for shutdown timeout (non-fatal if missing)
+			timeoutSec := 30
+			if cfg, err := config.Load(); err == nil {
+				timeoutSec = int(cfg.ShutdownTimeout().Seconds())
+			}
+
 			logger := log.ComponentCtx(ctx, "cmd")
 			logger.Info().
 				Str(log.FieldOperation, "container_restart").
 				Str(log.FieldContainer, name).
+				Int("shutdown_timeout_sec", timeoutSec).
 				Msg("Preparing to restart container")
 			ui.Blue.Printf("Sending %s for a coffee break...\n", name)
 
-			if err := client.RestartContainer(ctx, name); err != nil {
+			if err := client.RestartContainer(ctx, name, timeoutSec); err != nil {
 				logger.Error().
 					Err(err).
 					Str(log.FieldOperation, "container_restart").

--- a/internal/cmd/yacht.go
+++ b/internal/cmd/yacht.go
@@ -106,17 +106,21 @@ var yachtDownCmd = &cobra.Command{
 			return fmt.Errorf("%w. Run 'docker compose config' to debug", err)
 		}
 
+		// Determine shutdown timeout from config
+		timeoutSec := int(cfg.ShutdownTimeout().Seconds())
+
 		logger := log.Component("cmd")
 		logger.Info().
 			Str(log.FieldOperation, "compose_down").
 			Str(log.FieldPath, cfg.ComposeFile).
+			Int("shutdown_timeout_sec", timeoutSec).
 			Msg("Preparing to stop all services")
 		ui.Yellow.Println("Dropping anchor...")
 		compose, err := docker.NewComposeClient(cfg.ComposeFile, cfg.ProjectName())
 		if err != nil {
 			return fmt.Errorf("compose client: %w", err)
 		}
-		if err := compose.Down(ctx); err != nil {
+		if err := compose.DownWithTimeout(ctx, timeoutSec); err != nil {
 			return fmt.Errorf("compose down: %w", err)
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,9 @@ type Config struct {
 
 	// removeOrphans controls whether --remove-orphans is passed to docker compose up.
 	removeOrphans bool
+
+	// shutdownTimeout is the grace period for container stop operations (SIGTERM → SIGKILL).
+	shutdownTimeout time.Duration
 }
 
 // TunnelConfig holds tunnel provider-specific configuration.
@@ -191,6 +194,10 @@ type configFile struct {
 	// Defaults to true (preserving existing behavior). Set to false in shared environments
 	// where Bosun does not own all containers on the Docker host.
 	RemoveOrphans *bool `yaml:"remove_orphans"`
+
+	// ShutdownTimeout is the grace period for container stop operations (SIGTERM → SIGKILL).
+	// Defaults to 30s. Docker's default is 10s; increase for containers with long-running requests.
+	ShutdownTimeout reconcile.Duration `yaml:"shutdown_timeout"`
 }
 
 // FindRoot searches upward from the current directory to find the project root.
@@ -257,6 +264,7 @@ func LoadFrom(dir string) (*Config, error) {
 	driftAlertDebounce := extractDriftAlertDebounce(fileCfg)
 	domain := extractDomain(fileCfg)
 	removeOrphans := extractRemoveOrphans(fileCfg)
+	shutdownTimeout := extractShutdownTimeout(fileCfg)
 
 	return &Config{
 		Root:               dir,
@@ -267,6 +275,7 @@ func LoadFrom(dir string) (*Config, error) {
 		driftAlertDebounce: driftAlertDebounce,
 		domain:             domain,
 		removeOrphans:      removeOrphans,
+		shutdownTimeout:    shutdownTimeout,
 	}, nil
 }
 
@@ -313,6 +322,7 @@ func Load() (*Config, error) {
 	driftAlertDebounce := extractDriftAlertDebounce(fileCfg)
 	domain := extractDomain(fileCfg)
 	removeOrphans := extractRemoveOrphans(fileCfg)
+	shutdownTimeout := extractShutdownTimeout(fileCfg)
 
 	// Determine project name (defaults to directory name)
 	projectName := fileCfg.ProjectName
@@ -338,6 +348,7 @@ func Load() (*Config, error) {
 		driftAlertDebounce: driftAlertDebounce,
 		domain:             domain,
 		removeOrphans:      removeOrphans,
+		shutdownTimeout:    shutdownTimeout,
 	}
 
 	logger := log.Component("config")
@@ -583,6 +594,31 @@ func extractRemoveOrphans(cfg configFile) bool {
 // Defaults to true.
 func (c *Config) RemoveOrphans() bool {
 	return c.removeOrphans
+}
+
+// defaultShutdownTimeout is the default grace period for container stop operations.
+const defaultShutdownTimeout = 30 * time.Second
+
+// ShutdownTimeout returns the configured grace period for container stop operations.
+// Defaults to 30s. This is the time between SIGTERM and SIGKILL during container stops.
+func (c *Config) ShutdownTimeout() time.Duration {
+	return c.shutdownTimeout
+}
+
+// extractShutdownTimeout extracts the shutdown timeout from a parsed config.
+// Defaults to 30s when not configured.
+func extractShutdownTimeout(cfg configFile) time.Duration {
+	if cfg.ShutdownTimeout.Duration > 0 {
+		return cfg.ShutdownTimeout.Duration
+	}
+	// Check environment variable override
+	if v := os.Getenv("BOSUN_STOP_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+		log.Warn().Str("env", "BOSUN_STOP_TIMEOUT").Str("value", v).Msg("Skipping env var. Reason: invalid duration format")
+	}
+	return defaultShutdownTimeout
 }
 
 // getEnvOrDefault returns the value of the environment variable if set and non-empty,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1420,3 +1420,134 @@ func TestExtractCriticalContainers(t *testing.T) {
 		assert.Nil(t, extractCriticalContainers(cfg))
 	})
 }
+
+func TestShutdownTimeoutFromConfig(t *testing.T) {
+	t.Run("defaults to 30s when not configured", func(t *testing.T) {
+		tmpDir := evalSymlinks(t, t.TempDir())
+
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "manifest"), 0755))
+
+		content := `infrastructure:
+  containers:
+    - traefik
+`
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "bosun.yaml"), []byte(content), 0644))
+
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() { _ = os.Chdir(originalWd) }()
+		require.NoError(t, os.Chdir(tmpDir))
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.ShutdownTimeout())
+	})
+
+	t.Run("parses duration from bosun.yaml", func(t *testing.T) {
+		tmpDir := evalSymlinks(t, t.TempDir())
+
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "manifest"), 0755))
+
+		content := `shutdown_timeout: 120s
+`
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "bosun.yaml"), []byte(content), 0644))
+
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() { _ = os.Chdir(originalWd) }()
+		require.NoError(t, os.Chdir(tmpDir))
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 120*time.Second, cfg.ShutdownTimeout())
+	})
+
+	t.Run("respects BOSUN_STOP_TIMEOUT env var", func(t *testing.T) {
+		tmpDir := evalSymlinks(t, t.TempDir())
+
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "manifest"), 0755))
+
+		// No shutdown_timeout in YAML
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "bosun.yaml"), []byte(""), 0644))
+
+		t.Setenv("BOSUN_STOP_TIMEOUT", "90s")
+
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() { _ = os.Chdir(originalWd) }()
+		require.NoError(t, os.Chdir(tmpDir))
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 90*time.Second, cfg.ShutdownTimeout())
+	})
+
+	t.Run("YAML takes precedence over env var", func(t *testing.T) {
+		tmpDir := evalSymlinks(t, t.TempDir())
+
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "manifest"), 0755))
+
+		content := `shutdown_timeout: 60s
+`
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "bosun.yaml"), []byte(content), 0644))
+
+		t.Setenv("BOSUN_STOP_TIMEOUT", "90s")
+
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() { _ = os.Chdir(originalWd) }()
+		require.NoError(t, os.Chdir(tmpDir))
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 60*time.Second, cfg.ShutdownTimeout())
+	})
+}
+
+func TestLoadFrom_ShutdownTimeout(t *testing.T) {
+	t.Run("loads shutdown_timeout from directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		content := `shutdown_timeout: 45s
+`
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "bosun.yaml"), []byte(content), 0644))
+
+		cfg, err := LoadFrom(tmpDir)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, 45*time.Second, cfg.ShutdownTimeout())
+	})
+
+	t.Run("defaults to 30s when not set", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cfg, err := LoadFrom(tmpDir)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, 30*time.Second, cfg.ShutdownTimeout())
+	})
+}
+
+func TestExtractShutdownTimeout(t *testing.T) {
+	t.Run("returns default when zero", func(t *testing.T) {
+		cfg := configFile{}
+		assert.Equal(t, 30*time.Second, extractShutdownTimeout(cfg))
+	})
+
+	t.Run("returns configured duration", func(t *testing.T) {
+		cfg := configFile{ShutdownTimeout: reconcile.Duration{Duration: 120 * time.Second}}
+		assert.Equal(t, 120*time.Second, extractShutdownTimeout(cfg))
+	})
+
+	t.Run("respects env var when config is zero", func(t *testing.T) {
+		t.Setenv("BOSUN_STOP_TIMEOUT", "45s")
+		cfg := configFile{}
+		assert.Equal(t, 45*time.Second, extractShutdownTimeout(cfg))
+	})
+
+	t.Run("ignores invalid env var", func(t *testing.T) {
+		t.Setenv("BOSUN_STOP_TIMEOUT", "not-a-duration")
+		cfg := configFile{}
+		assert.Equal(t, 30*time.Second, extractShutdownTimeout(cfg))
+	})
+}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -265,13 +265,19 @@ func (c *Client) StopContainer(ctx context.Context, name string, timeout int) er
 	return nil
 }
 
-// RestartContainer restarts a container by name.
-func (c *Client) RestartContainer(ctx context.Context, name string) error {
+// RestartContainer restarts a container by name with the given timeout (seconds).
+// The timeout controls the grace period between SIGTERM and SIGKILL during the stop phase.
+func (c *Client) RestartContainer(ctx context.Context, name string, timeout ...int) error {
 	logger := log.ComponentCtx(ctx, log.ComponentDocker)
-	logger.Info().Str(log.FieldContainer, name).Msg("Restarting container")
 
-	timeout := 10
-	err := c.api.ContainerRestart(ctx, name, container.StopOptions{Timeout: &timeout})
+	t := 10
+	if len(timeout) > 0 && timeout[0] > 0 {
+		t = timeout[0]
+	}
+
+	logger.Info().Str(log.FieldContainer, name).Int("timeout", t).Msg("Restarting container")
+
+	err := c.api.ContainerRestart(ctx, name, container.StopOptions{Timeout: &t})
 	if err != nil {
 		logger.Error().Str(log.FieldContainer, name).Err(err).Msg("Failed to restart container")
 		return err

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -520,18 +520,37 @@ func TestClient_RemoveContainer(t *testing.T) {
 	}
 }
 
-func TestClient_RestartContainer(t *testing.T) {
+func TestClient_StopContainer(t *testing.T) {
 	tests := []struct {
 		name      string
 		container string
+		timeout   int
 		setup     func(*MockDockerAPI)
 		wantErr   bool
+		errMsg    string
 	}{
 		{
 			name:      "success",
 			container: "web",
+			timeout:   30,
 			setup: func(m *MockDockerAPI) {
-				m.ContainerRestartFunc = func(ctx context.Context, containerID string, options container.StopOptions) error {
+				m.ContainerStopFunc = func(ctx context.Context, containerID string, options container.StopOptions) error {
+					assert.Equal(t, "web", containerID)
+					require.NotNil(t, options.Timeout)
+					assert.Equal(t, 30, *options.Timeout)
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:      "custom timeout",
+			container: "api",
+			timeout:   120,
+			setup: func(m *MockDockerAPI) {
+				m.ContainerStopFunc = func(ctx context.Context, containerID string, options container.StopOptions) error {
+					require.NotNil(t, options.Timeout)
+					assert.Equal(t, 120, *options.Timeout)
 					return nil
 				}
 			},
@@ -540,6 +559,79 @@ func TestClient_RestartContainer(t *testing.T) {
 		{
 			name:      "failure",
 			container: "web",
+			timeout:   10,
+			setup: func(m *MockDockerAPI) {
+				m.ContainerStopFunc = func(ctx context.Context, containerID string, options container.StopOptions) error {
+					return errors.New("mock: container stop failed")
+				}
+			},
+			wantErr: true,
+			errMsg:  "stop container web",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := NewMockDockerAPI()
+			tt.setup(mock)
+			client := NewClientWithAPI(mock)
+
+			err := client.StopContainer(context.Background(), tt.container, tt.timeout)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, 1, mock.ContainerStopCalls)
+		})
+	}
+}
+
+func TestClient_RestartContainer(t *testing.T) {
+	tests := []struct {
+		name        string
+		container   string
+		timeout     []int
+		wantTimeout int
+		setup       func(*MockDockerAPI)
+		wantErr     bool
+	}{
+		{
+			name:        "success with default timeout",
+			container:   "web",
+			timeout:     nil,
+			wantTimeout: 10,
+			setup: func(m *MockDockerAPI) {
+				m.ContainerRestartFunc = func(ctx context.Context, containerID string, options container.StopOptions) error {
+					require.NotNil(t, options.Timeout)
+					assert.Equal(t, 10, *options.Timeout)
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:        "success with custom timeout",
+			container:   "web",
+			timeout:     []int{60},
+			wantTimeout: 60,
+			setup: func(m *MockDockerAPI) {
+				m.ContainerRestartFunc = func(ctx context.Context, containerID string, options container.StopOptions) error {
+					require.NotNil(t, options.Timeout)
+					assert.Equal(t, 60, *options.Timeout)
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:        "failure",
+			container:   "web",
+			timeout:     nil,
+			wantTimeout: 10,
 			setup: func(m *MockDockerAPI) {
 				m.ContainerRestartFunc = func(ctx context.Context, containerID string, options container.StopOptions) error {
 					return errMockRestart
@@ -555,7 +647,7 @@ func TestClient_RestartContainer(t *testing.T) {
 			tt.setup(mock)
 			client := NewClientWithAPI(mock)
 
-			err := client.RestartContainer(context.Background(), tt.container)
+			err := client.RestartContainer(context.Background(), tt.container, tt.timeout...)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -89,6 +89,21 @@ func (c *ComposeClient) Down(ctx context.Context) error {
 	return nil
 }
 
+// DownWithTimeout stops and removes services with a custom shutdown timeout.
+// The timeout is the grace period (in seconds) between SIGTERM and SIGKILL for each container.
+func (c *ComposeClient) DownWithTimeout(ctx context.Context, timeoutSeconds int) error {
+	args := c.baseArgs()
+	args = append(args, "down", "--timeout", fmt.Sprintf("%d", timeoutSeconds))
+
+	cmd := c.command(ctx, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker compose down: %w\n%s", err, output)
+	}
+
+	return nil
+}
+
 // Restart restarts services defined in the compose file.
 func (c *ComposeClient) Restart(ctx context.Context, services ...string) error {
 	args := c.baseArgs()

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -552,6 +552,68 @@ func TestComposeClient_Down_WithMockRunner(t *testing.T) {
 	}
 }
 
+func TestComposeClient_DownWithTimeout_WithMockRunner(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     string
+		project  string
+		timeout  int
+		opts     mockRunnerOpts
+		wantArgs []string
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name:     "success with 30s timeout",
+			file:     "compose.yml",
+			project:  "proj",
+			timeout:  30,
+			opts:     mockRunnerOpts{exitCode: "0"},
+			wantArgs: []string{"docker", "compose", "-p", "proj", "-f", "compose.yml", "down", "--timeout", "30"},
+			wantErr:  false,
+		},
+		{
+			name:     "success with 120s timeout",
+			file:     "compose.yml",
+			project:  "homelab",
+			timeout:  120,
+			opts:     mockRunnerOpts{exitCode: "0"},
+			wantArgs: []string{"docker", "compose", "-p", "homelab", "-f", "compose.yml", "down", "--timeout", "120"},
+			wantErr:  false,
+		},
+		{
+			name:    "failure",
+			file:    "compose.yml",
+			project: "proj",
+			timeout: 30,
+			opts:    mockRunnerOpts{exitCode: "1", stderr: "error"},
+			wantErr: true,
+			errMsg:  "docker compose down",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var recorded [][]string
+			c := &ComposeClient{
+				file:    tt.file,
+				project: tt.project,
+				runner:  newMockRunner(tt.opts, &recorded),
+			}
+
+			err := c.DownWithTimeout(context.Background(), tt.timeout)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, recorded, 1)
+				assert.Equal(t, tt.wantArgs, recorded[0])
+			}
+		})
+	}
+}
+
 func TestComposeClient_Restart_WithMockRunner(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Added `shutdown_timeout` config field in bosun.yaml (default 30s)
- `BOSUN_STOP_TIMEOUT` env var override
- `RestartContainer` now accepts optional timeout (backwards compatible variadic)
- Added `DownWithTimeout` to compose client for `docker compose down --timeout`
- Wired into `bosun yacht down` and `bosun crew restart` commands

## Motivation
No way to control how long containers get to drain connections before force-kill. Docker's SIGTERM→SIGKILL flow needs to be exposed through bosun.

## Test plan
- [ ] `client_test.go`: StopContainer (success, custom timeout, failure), RestartContainer (default + custom timeout)
- [ ] `compose_test.go`: DownWithTimeout mock runner tests
- [ ] `config_test.go`: ShutdownTimeout parsing (default, YAML, env var, precedence)
- [ ] `make test` passes

Closes #bosun-375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable shutdown grace period for container restart and compose operations.
  * Default timeout is set to 30 seconds for backward compatibility.
  * Timeout values can be customized via configuration file settings or environment variable overrides.

* **Tests**
  * Added comprehensive test coverage for shutdown timeout configuration, environment variable precedence, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->