### PR TITLE
fix(preflight): validate SSH deploy key permissions

### DIFF
--- a/internal/cmd/diagnostics_doctor.go
+++ b/internal/cmd/diagnostics_doctor.go
@@ -362,9 +362,9 @@ func checkDeployKeyPermissions() CheckResult {
 		_, _ = ui.Yellow.Println("  ! SSH deploy key not found (using agent or HTTPS?)")
 		return CheckResult{Warned: 1}
 	case res.Err != nil:
+		// res.Err already contains the chmod remediation command; print it
+		// directly to avoid duplicating the hint.
 		_, _ = ui.Red.Printf("  x %s\n", res.Err)
-		_, _ = ui.Blue.Println("      To fix this:")
-		_, _ = ui.Blue.Printf("      - Run: chmod 600 %s\n", res.Path)
 		return CheckResult{Failed: 1}
 	default:
 		_, _ = ui.Green.Printf("  * SSH deploy key permissions OK (%04o): %s\n", res.Mode, res.Path)

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -248,8 +248,13 @@ func CheckSSHKeyPermissions() SSHKeyPermResult {
 	for _, path := range sshKeyCandidates() {
 		info, err := os.Stat(path)
 		if err != nil {
-			// File does not exist — try the next candidate.
-			continue
+			if os.IsNotExist(err) {
+				// File does not exist — try the next candidate.
+				continue
+			}
+			// Any other error (e.g., permission denied on the parent directory)
+			// is surfaced immediately so it isn't silently ignored.
+			return SSHKeyPermResult{Path: path, Err: fmt.Errorf("reading SSH key metadata: %w", err)}
 		}
 
 		mode := info.Mode().Perm()

--- a/internal/preflight/ssh_test.go
+++ b/internal/preflight/ssh_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// evalDir resolves symlinks on a temp directory so macOS /var → /private/var
+// comparisons don't cause false mismatches.
+func evalDir(t *testing.T, dir string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	return resolved
+}
+
 func TestCheckSSHKeyPermissions_NoKeyFound(t *testing.T) {
 	t.Setenv("BOSUN_SSH_KEY", "")
 	t.Setenv("HOME", t.TempDir()) // HOME with no .ssh dir → no candidates exist
@@ -30,7 +39,7 @@ func TestCheckSSHKeyPermissions_SafePermissions(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
+			dir := evalDir(t, t.TempDir())
 			keyPath := filepath.Join(dir, "id_ed25519")
 			require.NoError(t, os.WriteFile(keyPath, []byte("fake key"), tc.mode))
 
@@ -56,7 +65,7 @@ func TestCheckSSHKeyPermissions_UnsafePermissions(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
+			dir := evalDir(t, t.TempDir())
 			keyPath := filepath.Join(dir, "deploy-key")
 			// Write with a safe mode first, then chmod to the target mode so
 			// the umask does not silently reduce the permission bits.
@@ -76,12 +85,12 @@ func TestCheckSSHKeyPermissions_UnsafePermissions(t *testing.T) {
 }
 
 func TestCheckSSHKeyPermissions_EnvVarTakesPrecedence(t *testing.T) {
-	dir := t.TempDir()
+	dir := evalDir(t, t.TempDir())
 	envKeyPath := filepath.Join(dir, "custom-key")
 	require.NoError(t, os.WriteFile(envKeyPath, []byte("fake key"), 0600))
 
 	// Also place a key in HOME/.ssh — should NOT be selected.
-	home := t.TempDir()
+	home := evalDir(t, t.TempDir())
 	sshDir := filepath.Join(home, ".ssh")
 	require.NoError(t, os.MkdirAll(sshDir, 0700))
 	homeKeyPath := filepath.Join(sshDir, "id_ed25519")
@@ -96,7 +105,7 @@ func TestCheckSSHKeyPermissions_EnvVarTakesPrecedence(t *testing.T) {
 }
 
 func TestCheckSSHKeyPermissions_FallsBackToHomeSSH(t *testing.T) {
-	home := t.TempDir()
+	home := evalDir(t, t.TempDir())
 	sshDir := filepath.Join(home, ".ssh")
 	require.NoError(t, os.MkdirAll(sshDir, 0700))
 	keyPath := filepath.Join(sshDir, "id_ed25519")


### PR DESCRIPTION
## Summary

- Add `CheckSSHKeyPermissions()` to the preflight package — validates SSH deploy key has safe permissions (0400 or 0600)
- Checks the same key resolution order as the reconcile SSH auth: `BOSUN_SSH_KEY` → `/config/deploy-key` → `/config/ssh-key` → `~/.ssh/id_ed25519` → `~/.ssh/id_rsa`
- Wire the check into `bosun doctor` via `checkDeployKeyPermissions()` — surfaces actionable error with `chmod 600` command when permissions are wrong
- Missing key is a warning (agent/HTTPS may be in use), wrong permissions is a hard failure

Fixes #172

## Test plan

- [x] Unit tests for permission validation (0600 ok, 0400 ok, 0644 rejected, 0755 rejected)
- [x] `BOSUN_SSH_KEY` takes precedence over `~/.ssh/id_ed25519`
- [x] Falls back to `~/.ssh/id_ed25519` when env var unset
- [x] No key found → warning (not error)
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)