### PR TITLE
fix(reconcile): fire all post-sync hooks unconditionally for remote deploys

### DIFF
--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -753,7 +753,13 @@ func (r *Reconciler) executePostSyncHooks(ctx context.Context, previousCommit, c
 	// Prefer written-files from content-hash sync over git diff.
 	var changedFiles []string
 	diffFailed := false
-	if deployResult != nil && len(deployResult.WrittenFiles) > 0 {
+	remoteMode := deployResult == nil && r.config.TargetHost != ""
+	if remoteMode {
+		// Remote deploys return nil DeployResult (no file-level tracking).
+		// Fire all hooks unconditionally — a false-positive restart is better
+		// than stale configs on a FUSE mount. See GitHub #197.
+		logger.Info().Msg("Remote deploy: firing all post-sync hooks (no file-level tracking available)")
+	} else if deployResult != nil && len(deployResult.WrittenFiles) > 0 {
 		changedFiles = deployResult.WrittenFiles
 		logger.Debug().Int("files", len(changedFiles)).Msg("Using written-files list for post-sync hooks")
 	} else {
@@ -769,16 +775,18 @@ func (r *Reconciler) executePostSyncHooks(ctx context.Context, previousCommit, c
 		}
 	}
 
-	if len(changedFiles) == 0 && !diffFailed {
+	if len(changedFiles) == 0 && !diffFailed && !remoteMode {
 		return
 	}
 
-	// When diff fails (shallow clone), fire all hooks unconditionally.
+	// When diff fails (shallow clone) or deploy is remote, fire all hooks unconditionally.
 	// A false-positive restart is safer than stale configs on FUSE mounts.
 	var matched []PostSyncHook
-	if diffFailed {
+	if diffFailed || remoteMode {
 		matched = dedupeHooksByContainer(r.config.PostSyncHooks)
-		logger.Info().Int("hooks", len(matched)).Msg("Diff unavailable, firing all configured hooks")
+		if diffFailed {
+			logger.Info().Int("hooks", len(matched)).Msg("Diff unavailable, firing all configured hooks")
+		}
 	} else {
 		matched = EvaluatePostSyncHooks(changedFiles, r.config.PostSyncHooks)
 	}

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -1342,6 +1342,77 @@ func TestReconcilerExecutePostSyncHooks(t *testing.T) {
 		r.executePostSyncHooks(context.Background(), "aaa", "bbb", nil)
 		assert.True(t, restartCalled)
 	})
+
+	t.Run("remote deploy fires all hooks unconditionally", func(t *testing.T) {
+		restartedContainers := map[string]bool{}
+		mockAPI := newReconcileMockDockerAPI()
+		mockAPI.containerRestartFunc = func(ctx context.Context, cID string, opts container.StopOptions) error {
+			restartedContainers[cID] = true
+			return nil
+		}
+		client := docker.NewClientWithAPI(mockAPI)
+
+		cfg := &Config{
+			TargetHost: "user@remote-host",
+			PostSyncHooks: []PostSyncHook{
+				{Container: "traefik", Paths: []string{"traefik/**"}, Action: "restart"},
+				{Container: "authelia", Paths: []string{"authelia/**"}, Action: "restart"},
+			},
+		}
+		r := NewReconciler(cfg)
+		r.dockerClientFn = func() *docker.Client { return client }
+
+		// deployResult is nil (remote mode), all hooks should fire
+		r.executePostSyncHooks(context.Background(), "aaa", "bbb", nil)
+		assert.True(t, restartedContainers["traefik"], "traefik hook should fire for remote deploy")
+		assert.True(t, restartedContainers["authelia"], "authelia hook should fire for remote deploy")
+	})
+
+	t.Run("local deploy with WrittenFiles fires only matching hooks", func(t *testing.T) {
+		restartedContainers := map[string]bool{}
+		mockAPI := newReconcileMockDockerAPI()
+		mockAPI.containerRestartFunc = func(ctx context.Context, cID string, opts container.StopOptions) error {
+			restartedContainers[cID] = true
+			return nil
+		}
+		client := docker.NewClientWithAPI(mockAPI)
+
+		cfg := &Config{
+			PostSyncHooks: []PostSyncHook{
+				{Container: "traefik", Paths: []string{"traefik/**"}, Action: "restart"},
+				{Container: "authelia", Paths: []string{"authelia/**"}, Action: "restart"},
+			},
+		}
+		r := NewReconciler(cfg)
+		r.dockerClientFn = func() *docker.Client { return client }
+
+		// Only traefik files changed — authelia hook should NOT fire
+		result := &DeployResult{WrittenFiles: []string{"traefik/dynamic.yml"}}
+		r.executePostSyncHooks(context.Background(), "aaa", "bbb", result)
+		assert.True(t, restartedContainers["traefik"], "traefik hook should fire for matching files")
+		assert.False(t, restartedContainers["authelia"], "authelia hook should NOT fire without matching files")
+	})
+
+	t.Run("nil deploy result without remote target uses git diff", func(t *testing.T) {
+		// When TargetHost is empty and deployResult is nil, fall back to git diff
+		// (not the remote-mode unconditional path).
+		gitOps := &mockGitOps{diffFiles: []string{}}
+		cfg := &Config{
+			PostSyncHooks: []PostSyncHook{
+				{Container: "traefik", Paths: []string{"traefik/**"}, Action: "restart"},
+			},
+		}
+		dockerCalled := false
+		r := NewReconciler(cfg, WithGitOperations(gitOps))
+		r.dockerClientFn = func() *docker.Client {
+			dockerCalled = true
+			return nil
+		}
+
+		// No TargetHost, nil deployResult, empty diff — hooks should NOT fire
+		r.executePostSyncHooks(context.Background(), "aaa", "bbb", nil)
+		assert.False(t, dockerCalled, "hooks should not fire when diff is empty and not remote mode")
+	})
 }
 
 // --- Reconciler.reloadProjectConfig tests ---


### PR DESCRIPTION
## Summary

- When `deployResult` is nil and `TargetHost` is set, fire all configured hooks unconditionally
- Log info message indicating remote deploy hook behavior
- Preserves existing local deploy behavior (file-level hook matching)

Fixes #197

## Test plan

- [x] New test: remote deploy fires all hooks unconditionally
- [x] New test: local deploy with WrittenFiles fires only matching hooks
- [x] New test: nil result without remote target falls back to git diff
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)