### PR TITLE
refactor(config): migrate 3 daemon-only fields to ConfigField[T]

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -61,15 +61,10 @@ type Config struct {
 	// Drift check settings
 	DriftInterval          time.Duration // Interval for periodic drift checks (0 disables, default: 5m)
 	DriftAlertCooldown     time.Duration // Cooldown between repeated drift alerts per item (default: 1h)
-	DriftAlertDebounce     time.Duration // Debounce window before first drift alert fires (0 = disabled, default: 0)
-	DriftResolveAlerts     bool          // Send "drift resolved" alerts (default: true)
-	DriftSelfHeal          bool          // Trigger reconciliation when drift detected (default: false)
-	DriftSelfHealCooldown  time.Duration // Minimum interval between self-heal reconciliations (default: 15m)
-
-	// "from env" flags: when true, the corresponding field must not be overwritten by bosun.yaml hot-reload.
-	DriftAlertDebounceFromEnv    bool
-	DriftSelfHealFromEnv         bool
-	DriftSelfHealCooldownFromEnv bool
+	DriftAlertDebounce    reconcile.ConfigField[time.Duration] // Debounce window before first drift alert fires (0 = disabled, default: 0)
+	DriftResolveAlerts    bool                                // Send "drift resolved" alerts (default: true)
+	DriftSelfHeal         reconcile.ConfigField[bool]         // Trigger reconciliation when drift detected (default: false)
+	DriftSelfHealCooldown reconcile.ConfigField[time.Duration] // Minimum interval between self-heal reconciliations (default: 15m)
 
 	// Content-hash sync settings
 	ContentHashSync bool // Compare file hashes before writing (default: true)
@@ -103,7 +98,7 @@ func DefaultConfig() *Config {
 		DriftInterval:          5 * time.Minute,
 		DriftAlertCooldown:     time.Hour,
 		DriftResolveAlerts:     true,
-		DriftSelfHealCooldown:  15 * time.Minute,
+		DriftSelfHealCooldown:  reconcile.NewConfigField(15 * time.Minute),
 		ContentHashSync:    true,
 		RemoveOrphans:      true,
 	}
@@ -1086,9 +1081,9 @@ func (d *Daemon) driftConfig() driftRuntimeConfig {
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
 	return driftRuntimeConfig{
-		driftAlertDebounce:    d.config.DriftAlertDebounce,
-		driftSelfHeal:         d.config.DriftSelfHeal,
-		driftSelfHealCooldown: d.config.DriftSelfHealCooldown,
+		driftAlertDebounce:    d.config.DriftAlertDebounce.Value,
+		driftSelfHeal:         d.config.DriftSelfHeal.Value,
+		driftSelfHealCooldown: d.config.DriftSelfHealCooldown.Value,
 	}
 }
 
@@ -1110,38 +1105,38 @@ func (d *Daemon) reloadDaemonConfig() {
 
 	changed := false
 
-	if !d.config.DriftAlertDebounceFromEnv {
+	if !d.config.DriftAlertDebounce.FromEnv() {
 		newVal := projectCfg.DriftAlertDebounce()
-		if newVal != d.config.DriftAlertDebounce {
-			d.config.DriftAlertDebounce = newVal
+		if newVal != d.config.DriftAlertDebounce.Value {
+			d.config.DriftAlertDebounce.SetFromFile(newVal)
 			changed = true
 		}
 	}
 
-	if !d.config.DriftSelfHealFromEnv {
+	if !d.config.DriftSelfHeal.FromEnv() {
 		newVal := projectCfg.DriftSelfHeal()
-		if newVal != d.config.DriftSelfHeal {
-			d.config.DriftSelfHeal = newVal
+		if newVal != d.config.DriftSelfHeal.Value {
+			d.config.DriftSelfHeal.SetFromFile(newVal)
 			changed = true
 		}
 	}
 
-	if !d.config.DriftSelfHealCooldownFromEnv {
+	if !d.config.DriftSelfHealCooldown.FromEnv() {
 		newVal := projectCfg.DriftSelfHealCooldown()
 		if newVal == 0 {
-			newVal = DefaultConfig().DriftSelfHealCooldown
+			newVal = DefaultConfig().DriftSelfHealCooldown.Value
 		}
-		if newVal != d.config.DriftSelfHealCooldown {
-			d.config.DriftSelfHealCooldown = newVal
+		if newVal != d.config.DriftSelfHealCooldown.Value {
+			d.config.DriftSelfHealCooldown.SetFromFile(newVal)
 			changed = true
 		}
 	}
 
 	if changed {
 		logger.Info().
-			Dur("drift_alert_debounce", d.config.DriftAlertDebounce).
-			Bool("drift_self_heal", d.config.DriftSelfHeal).
-			Dur("drift_self_heal_cooldown", d.config.DriftSelfHealCooldown).
+			Dur("drift_alert_debounce", d.config.DriftAlertDebounce.Value).
+			Bool("drift_self_heal", d.config.DriftSelfHeal.Value).
+			Dur("drift_self_heal_cooldown", d.config.DriftSelfHealCooldown.Value).
 			Msg("Daemon config reloaded from bosun.yaml")
 	}
 }
@@ -1524,8 +1519,7 @@ func ConfigFromEnv() *Config {
 			if d < 0 {
 				log.Warn().Str("env", "BOSUN_DRIFT_ALERT_DEBOUNCE").Str("value", v).Msg("Skipping env var. Reason: duration must not be negative")
 			} else {
-				cfg.DriftAlertDebounce = d
-				cfg.DriftAlertDebounceFromEnv = true
+				cfg.DriftAlertDebounce.SetFromEnv(d)
 			}
 		} else {
 			log.Warn().Str("env", "BOSUN_DRIFT_ALERT_DEBOUNCE").Str("value", v).Msg("Skipping env var. Reason: invalid duration format")
@@ -1546,16 +1540,14 @@ func ConfigFromEnv() *Config {
 
 	// Drift self-healing (default: false)
 	if v := os.Getenv("BOSUN_DRIFT_SELF_HEAL"); v != "" {
-		cfg.DriftSelfHeal = v == "true" || v == "1"
-		cfg.DriftSelfHealFromEnv = true
+		cfg.DriftSelfHeal.SetFromEnv(v == "true" || v == "1")
 	}
 	if v := os.Getenv("BOSUN_DRIFT_SELF_HEAL_COOLDOWN"); v != "" {
 		if d, ok := parseDurationOrSeconds(v); ok {
 			if d <= 0 {
 				log.Warn().Str("env", "BOSUN_DRIFT_SELF_HEAL_COOLDOWN").Str("value", v).Msg("Skipping env var. Reason: duration must be positive")
 			} else {
-				cfg.DriftSelfHealCooldown = d
-				cfg.DriftSelfHealCooldownFromEnv = true
+				cfg.DriftSelfHealCooldown.SetFromEnv(d)
 			}
 		} else {
 			log.Warn().Str("env", "BOSUN_DRIFT_SELF_HEAL_COOLDOWN").Str("value", v).Msg("Skipping env var. Reason: invalid duration format")
@@ -1594,16 +1586,16 @@ func ConfigFromEnv() *Config {
 		rcfg.OnSuccess = alertCfg.OnSuccess
 
 		// Config file debounce value: env var takes precedence (already parsed above).
-		if !cfg.DriftAlertDebounceFromEnv && projectCfg.DriftAlertDebounce() > 0 {
-			cfg.DriftAlertDebounce = projectCfg.DriftAlertDebounce()
+		if !cfg.DriftAlertDebounce.FromEnv() && projectCfg.DriftAlertDebounce() > 0 {
+			cfg.DriftAlertDebounce.SetFromFile(projectCfg.DriftAlertDebounce())
 		}
 
 		// Drift self-heal from config file; env var takes precedence.
-		if !cfg.DriftSelfHealFromEnv {
-			cfg.DriftSelfHeal = projectCfg.DriftSelfHeal()
+		if !cfg.DriftSelfHeal.FromEnv() {
+			cfg.DriftSelfHeal.SetFromFile(projectCfg.DriftSelfHeal())
 		}
-		if !cfg.DriftSelfHealCooldownFromEnv && projectCfg.DriftSelfHealCooldown() > 0 {
-			cfg.DriftSelfHealCooldown = projectCfg.DriftSelfHealCooldown()
+		if !cfg.DriftSelfHealCooldown.FromEnv() && projectCfg.DriftSelfHealCooldown() > 0 {
+			cfg.DriftSelfHealCooldown.SetFromFile(projectCfg.DriftSelfHealCooldown())
 		}
 
 		// Load remove_orphans from project config; env var (parsed above) takes precedence.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -837,7 +837,7 @@ func TestConfigFromEnv_DriftAlertDebounce(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.Equal(t, 5*time.Minute, cfg.DriftAlertDebounce)
+		assert.Equal(t, 5*time.Minute, cfg.DriftAlertDebounce.Value)
 	})
 
 	t.Run("parses bare seconds", func(t *testing.T) {
@@ -845,13 +845,13 @@ func TestConfigFromEnv_DriftAlertDebounce(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.Equal(t, 300*time.Second, cfg.DriftAlertDebounce)
+		assert.Equal(t, 300*time.Second, cfg.DriftAlertDebounce.Value)
 	})
 
 	t.Run("defaults to 0 when not set", func(t *testing.T) {
 		cfg := ConfigFromEnv()
 
-		assert.Equal(t, time.Duration(0), cfg.DriftAlertDebounce)
+		assert.Equal(t, time.Duration(0), cfg.DriftAlertDebounce.Value)
 	})
 
 	t.Run("invalid value keeps default 0", func(t *testing.T) {
@@ -859,14 +859,14 @@ func TestConfigFromEnv_DriftAlertDebounce(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.Equal(t, time.Duration(0), cfg.DriftAlertDebounce)
+		assert.Equal(t, time.Duration(0), cfg.DriftAlertDebounce.Value)
 	})
 }
 
 func TestDefaultConfig_DriftAlertDebounce(t *testing.T) {
 	cfg := DefaultConfig()
 
-	assert.Equal(t, time.Duration(0), cfg.DriftAlertDebounce, "DriftAlertDebounce should default to 0 (disabled)")
+	assert.Equal(t, time.Duration(0), cfg.DriftAlertDebounce.Value, "DriftAlertDebounce should default to 0 (disabled)")
 }
 
 func TestConfigFromEnv_DriftAlertDebounce_EnvZeroOverridesConfig(t *testing.T) {
@@ -889,7 +889,7 @@ drift_alert_debounce: "10m"
 
 	cfg := ConfigFromEnv()
 
-	assert.Equal(t, time.Duration(0), cfg.DriftAlertDebounce,
+	assert.Equal(t, time.Duration(0), cfg.DriftAlertDebounce.Value,
 		"env var set to '0' should disable debounce, not fall through to config file value")
 }
 
@@ -1905,7 +1905,7 @@ func TestRunDriftCheck_DebounceDisabled(t *testing.T) {
 	// When debounce is 0 (default), alerts fire immediately on first detection.
 	provider := &testAlertProvider{}
 	d := newAlertDaemon(t, provider)
-	d.config.DriftAlertDebounce = 0
+	d.config.DriftAlertDebounce = reconcile.NewConfigField(time.Duration(0))
 	d.config.DriftInterval = 5 * time.Minute
 
 	stateFile := d.config.ReconcileConfig.StateFile
@@ -2207,8 +2207,8 @@ func TestParseDurationOrSeconds(t *testing.T) {
 func TestDefaultConfig_DriftSelfHeal(t *testing.T) {
 	cfg := DefaultConfig()
 
-	assert.False(t, cfg.DriftSelfHeal, "DriftSelfHeal should be false by default")
-	assert.Equal(t, 15*time.Minute, cfg.DriftSelfHealCooldown, "DriftSelfHealCooldown should default to 15m")
+	assert.False(t, cfg.DriftSelfHeal.Value, "DriftSelfHeal should be false by default")
+	assert.Equal(t, 15*time.Minute, cfg.DriftSelfHealCooldown.Value, "DriftSelfHealCooldown should default to 15m")
 }
 
 func TestConfigFromEnv_DriftSelfHeal(t *testing.T) {
@@ -2217,7 +2217,7 @@ func TestConfigFromEnv_DriftSelfHeal(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.True(t, cfg.DriftSelfHeal)
+		assert.True(t, cfg.DriftSelfHeal.Value)
 	})
 
 	t.Run("1 enables self-heal", func(t *testing.T) {
@@ -2225,7 +2225,7 @@ func TestConfigFromEnv_DriftSelfHeal(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.True(t, cfg.DriftSelfHeal)
+		assert.True(t, cfg.DriftSelfHeal.Value)
 	})
 
 	t.Run("false disables self-heal", func(t *testing.T) {
@@ -2233,13 +2233,13 @@ func TestConfigFromEnv_DriftSelfHeal(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.False(t, cfg.DriftSelfHeal)
+		assert.False(t, cfg.DriftSelfHeal.Value)
 	})
 
 	t.Run("defaults to false when not set", func(t *testing.T) {
 		cfg := ConfigFromEnv()
 
-		assert.False(t, cfg.DriftSelfHeal)
+		assert.False(t, cfg.DriftSelfHeal.Value)
 	})
 }
 
@@ -2249,7 +2249,7 @@ func TestConfigFromEnv_DriftSelfHealCooldown(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.Equal(t, 10*time.Minute, cfg.DriftSelfHealCooldown)
+		assert.Equal(t, 10*time.Minute, cfg.DriftSelfHealCooldown.Value)
 	})
 
 	t.Run("parses bare seconds", func(t *testing.T) {
@@ -2257,13 +2257,13 @@ func TestConfigFromEnv_DriftSelfHealCooldown(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.Equal(t, 600*time.Second, cfg.DriftSelfHealCooldown)
+		assert.Equal(t, 600*time.Second, cfg.DriftSelfHealCooldown.Value)
 	})
 
 	t.Run("defaults to 15m when not set", func(t *testing.T) {
 		cfg := ConfigFromEnv()
 
-		assert.Equal(t, 15*time.Minute, cfg.DriftSelfHealCooldown)
+		assert.Equal(t, 15*time.Minute, cfg.DriftSelfHealCooldown.Value)
 	})
 
 	t.Run("invalid value keeps default", func(t *testing.T) {
@@ -2271,7 +2271,7 @@ func TestConfigFromEnv_DriftSelfHealCooldown(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.Equal(t, 15*time.Minute, cfg.DriftSelfHealCooldown)
+		assert.Equal(t, 15*time.Minute, cfg.DriftSelfHealCooldown.Value)
 	})
 
 	t.Run("zero or negative keeps default", func(t *testing.T) {
@@ -2279,15 +2279,15 @@ func TestConfigFromEnv_DriftSelfHealCooldown(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.Equal(t, 15*time.Minute, cfg.DriftSelfHealCooldown)
+		assert.Equal(t, 15*time.Minute, cfg.DriftSelfHealCooldown.Value)
 	})
 }
 
 func TestMaybeSelfHeal_TriggersWhenEnabled(t *testing.T) {
 	provider := &testAlertProvider{}
 	d := newAlertDaemon(t, provider)
-	d.config.DriftSelfHeal = true
-	d.config.DriftSelfHealCooldown = 15 * time.Minute
+	d.config.DriftSelfHeal = reconcile.NewConfigField(true)
+	d.config.DriftSelfHealCooldown = reconcile.NewConfigField(15 * time.Minute)
 
 	report := &reconcile.DriftReport{
 		CheckedAt: time.Now(),
@@ -2309,8 +2309,8 @@ func TestMaybeSelfHeal_TriggersWhenEnabled(t *testing.T) {
 func TestMaybeSelfHeal_SkipsWhenReconciling(t *testing.T) {
 	provider := &testAlertProvider{}
 	d := newAlertDaemon(t, provider)
-	d.config.DriftSelfHeal = true
-	d.config.DriftSelfHealCooldown = 15 * time.Minute
+	d.config.DriftSelfHeal = reconcile.NewConfigField(true)
+	d.config.DriftSelfHealCooldown = reconcile.NewConfigField(15 * time.Minute)
 
 	// Simulate reconciliation in progress.
 	d.reconcileMu.Lock()
@@ -2339,8 +2339,8 @@ func TestMaybeSelfHeal_SkipsWhenReconciling(t *testing.T) {
 func TestMaybeSelfHeal_RespectsCooldown(t *testing.T) {
 	provider := &testAlertProvider{}
 	d := newAlertDaemon(t, provider)
-	d.config.DriftSelfHeal = true
-	d.config.DriftSelfHealCooldown = 15 * time.Minute
+	d.config.DriftSelfHeal = reconcile.NewConfigField(true)
+	d.config.DriftSelfHealCooldown = reconcile.NewConfigField(15 * time.Minute)
 
 	// Simulate a recent self-heal.
 	d.lastSelfHeal = time.Now().Add(-5 * time.Minute) // 5 minutes ago, within 15m cooldown
@@ -2363,8 +2363,8 @@ func TestMaybeSelfHeal_RespectsCooldown(t *testing.T) {
 func TestMaybeSelfHeal_TriggersAfterCooldownExpires(t *testing.T) {
 	provider := &testAlertProvider{}
 	d := newAlertDaemon(t, provider)
-	d.config.DriftSelfHeal = true
-	d.config.DriftSelfHealCooldown = 15 * time.Minute
+	d.config.DriftSelfHeal = reconcile.NewConfigField(true)
+	d.config.DriftSelfHealCooldown = reconcile.NewConfigField(15 * time.Minute)
 
 	// Simulate a self-heal that happened 20 minutes ago (past the 15m cooldown).
 	d.lastSelfHeal = time.Now().Add(-20 * time.Minute)
@@ -2546,9 +2546,9 @@ drift_self_heal_cooldown: "20m"
 
 	d := &Daemon{
 		config: &Config{
-			DriftAlertDebounce:   0,
-			DriftSelfHeal:        false,
-			DriftSelfHealCooldown: 15 * time.Minute,
+			DriftAlertDebounce:    reconcile.NewConfigField(time.Duration(0)),
+			DriftSelfHeal:         reconcile.NewConfigField(false),
+			DriftSelfHealCooldown: reconcile.NewConfigField(15 * time.Minute),
 		},
 	}
 
@@ -2556,9 +2556,9 @@ drift_self_heal_cooldown: "20m"
 
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
-	assert.Equal(t, 5*time.Minute, d.config.DriftAlertDebounce)
-	assert.True(t, d.config.DriftSelfHeal)
-	assert.Equal(t, 20*time.Minute, d.config.DriftSelfHealCooldown)
+	assert.Equal(t, 5*time.Minute, d.config.DriftAlertDebounce.Value)
+	assert.True(t, d.config.DriftSelfHeal.Value)
+	assert.Equal(t, 20*time.Minute, d.config.DriftSelfHealCooldown.Value)
 }
 
 func TestReloadDaemonConfig_EnvVarsPreventsOverride(t *testing.T) {
@@ -2581,12 +2581,9 @@ drift_self_heal_cooldown: "20m"
 	// All three fields are locked by env vars.
 	d := &Daemon{
 		config: &Config{
-			DriftAlertDebounce:           2 * time.Minute,
-			DriftAlertDebounceFromEnv:    true,
-			DriftSelfHeal:                false,
-			DriftSelfHealFromEnv:         true,
-			DriftSelfHealCooldown:        10 * time.Minute,
-			DriftSelfHealCooldownFromEnv: true,
+			DriftAlertDebounce:    reconcile.EnvConfigField(2 * time.Minute),
+			DriftSelfHeal:         reconcile.EnvConfigField(false),
+			DriftSelfHealCooldown: reconcile.EnvConfigField(10 * time.Minute),
 		},
 	}
 
@@ -2595,9 +2592,9 @@ drift_self_heal_cooldown: "20m"
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
 	// Values must stay as set by "env vars" — bosun.yaml must not overwrite them.
-	assert.Equal(t, 2*time.Minute, d.config.DriftAlertDebounce, "DriftAlertDebounce must not change when locked by env")
-	assert.False(t, d.config.DriftSelfHeal, "DriftSelfHeal must not change when locked by env")
-	assert.Equal(t, 10*time.Minute, d.config.DriftSelfHealCooldown, "DriftSelfHealCooldown must not change when locked by env")
+	assert.Equal(t, 2*time.Minute, d.config.DriftAlertDebounce.Value, "DriftAlertDebounce must not change when locked by env")
+	assert.False(t, d.config.DriftSelfHeal.Value, "DriftSelfHeal must not change when locked by env")
+	assert.Equal(t, 10*time.Minute, d.config.DriftSelfHealCooldown.Value, "DriftSelfHealCooldown must not change when locked by env")
 }
 
 func TestReloadDaemonConfig_NoConfigFile_IsNoop(t *testing.T) {
@@ -2611,9 +2608,9 @@ func TestReloadDaemonConfig_NoConfigFile_IsNoop(t *testing.T) {
 
 	d := &Daemon{
 		config: &Config{
-			DriftAlertDebounce:   3 * time.Minute,
-			DriftSelfHeal:        true,
-			DriftSelfHealCooldown: 12 * time.Minute,
+			DriftAlertDebounce:    reconcile.NewConfigField(3 * time.Minute),
+			DriftSelfHeal:         reconcile.NewConfigField(true),
+			DriftSelfHealCooldown: reconcile.NewConfigField(12 * time.Minute),
 		},
 	}
 
@@ -2622,17 +2619,17 @@ func TestReloadDaemonConfig_NoConfigFile_IsNoop(t *testing.T) {
 
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
-	assert.Equal(t, 3*time.Minute, d.config.DriftAlertDebounce)
-	assert.True(t, d.config.DriftSelfHeal)
-	assert.Equal(t, 12*time.Minute, d.config.DriftSelfHealCooldown)
+	assert.Equal(t, 3*time.Minute, d.config.DriftAlertDebounce.Value)
+	assert.True(t, d.config.DriftSelfHeal.Value)
+	assert.Equal(t, 12*time.Minute, d.config.DriftSelfHealCooldown.Value)
 }
 
 func TestDriftConfig_ReturnsConsistentSnapshot(t *testing.T) {
 	d := &Daemon{
 		config: &Config{
-			DriftAlertDebounce:   7 * time.Minute,
-			DriftSelfHeal:        true,
-			DriftSelfHealCooldown: 25 * time.Minute,
+			DriftAlertDebounce:    reconcile.NewConfigField(7 * time.Minute),
+			DriftSelfHeal:         reconcile.NewConfigField(true),
+			DriftSelfHealCooldown: reconcile.NewConfigField(25 * time.Minute),
 		},
 	}
 
@@ -2649,13 +2646,13 @@ func TestConfigFromEnv_DriftFromEnvFlags(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.True(t, cfg.DriftAlertDebounceFromEnv)
+		assert.True(t, cfg.DriftAlertDebounce.FromEnv())
 	})
 
 	t.Run("DriftAlertDebounceFromEnv false when env var absent", func(t *testing.T) {
 		cfg := ConfigFromEnv()
 
-		assert.False(t, cfg.DriftAlertDebounceFromEnv)
+		assert.False(t, cfg.DriftAlertDebounce.FromEnv())
 	})
 
 	t.Run("DriftSelfHealFromEnv set when env var present", func(t *testing.T) {
@@ -2663,13 +2660,13 @@ func TestConfigFromEnv_DriftFromEnvFlags(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.True(t, cfg.DriftSelfHealFromEnv)
+		assert.True(t, cfg.DriftSelfHeal.FromEnv())
 	})
 
 	t.Run("DriftSelfHealFromEnv false when env var absent", func(t *testing.T) {
 		cfg := ConfigFromEnv()
 
-		assert.False(t, cfg.DriftSelfHealFromEnv)
+		assert.False(t, cfg.DriftSelfHeal.FromEnv())
 	})
 
 	t.Run("DriftSelfHealCooldownFromEnv set when env var present", func(t *testing.T) {
@@ -2677,12 +2674,12 @@ func TestConfigFromEnv_DriftFromEnvFlags(t *testing.T) {
 
 		cfg := ConfigFromEnv()
 
-		assert.True(t, cfg.DriftSelfHealCooldownFromEnv)
+		assert.True(t, cfg.DriftSelfHealCooldown.FromEnv())
 	})
 
 	t.Run("DriftSelfHealCooldownFromEnv false when env var absent", func(t *testing.T) {
 		cfg := ConfigFromEnv()
 
-		assert.False(t, cfg.DriftSelfHealCooldownFromEnv)
+		assert.False(t, cfg.DriftSelfHealCooldown.FromEnv())
 	})
 }


### PR DESCRIPTION
## Summary

Final PR (3 of 3) for the ConfigField[T] refactor (stacked on #208).

Migrates the last 3 `*FromEnv` fields from `daemon.Config`:
- `DriftAlertDebounce` (`reconcile.ConfigField[time.Duration]`)
- `DriftSelfHeal` (`reconcile.ConfigField[bool]`)
- `DriftSelfHealCooldown` (`reconcile.ConfigField[time.Duration]`)

**All 11 `*FromEnv` booleans are now eliminated from the codebase.**

**Net result: -11 lines** (83 added, 94 removed).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] All config-related daemon tests pass (reload, env override, defaults, snapshot)
- [x] Note: pre-existing goroutine leak in daemon test suite causes timeout — unrelated to this change

Closes bosun-j1c

🤖 Generated with [Claude Code](https://claude.com/claude-code)