### PR TITLE
fix: doctor and discovery diagnostic accuracy (Cluster J)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,6 +394,7 @@ All bosun-specific env vars use the `BOSUN_` prefix. Legacy unprefixed vars (`RE
 - **WrittenFiles paths are staging-relative**: Content-hash sync (`CopyDirIfChanged`) returns paths relative to each deploy target dir. `deployLocal` prefixes them with `t.RelPath` via `PrefixLatest`. Hook globs must use staging-relative paths (e.g., `appdata/authelia/**`), not repo-relative. Git-diff fallback uses different (repo-relative) paths — the two code paths are not interchangeable
 - **`filepath.Join` silently drops prefix for absolute paths**: `filepath.Join("prefix", "/absolute/path")` returns `/absolute/path`. When adding paths to `WrittenFiles`, always use relative paths (e.g., `filepath.Base()`) so `PrefixLatest` works correctly
 - **CLAUDE.md symlink and the Edit tool**: `Read` must target `AGENTS.md` before `Edit` will work. The Edit tool tracks file modification times — if the symlink target was modified externally, Edit refuses with "file modified since read"
+- **`FindRoot` `$HOME`-anchor refusal**: `FindRoot` refuses to anchor on `manifest/` or `manifests/` alone when the candidate dir equals `$HOME` (after `filepath.EvalSymlinks` normalization on both sides). These generic directory names collide with npm, OCI tooling, and packaging pipelines. Strong markers (`bosun.yaml`, `bosun.yml`, `bosun/docker-compose.yml`) are accepted unconditionally everywhere, including inside `$HOME`.
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker

--- a/internal/cmd/diagnostics_doctor.go
+++ b/internal/cmd/diagnostics_doctor.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -202,7 +203,13 @@ func checkManifestDirectory(cfg *config.Config) CheckResult {
 // checkStateDir verifies the deploy-state directory is writable.
 // The state dir defaults to reconcile.DefaultStateDir but is overridden by
 // the BOSUN_STATE_DIR environment variable (same logic as the daemon).
+// On Windows the default path (/var/lib/bosun) is meaningless — the check
+// is skipped unless BOSUN_STATE_DIR overrides it with a valid path.
 func checkStateDir() CheckResult {
+	if runtime.GOOS == "windows" && os.Getenv("BOSUN_STATE_DIR") == "" {
+		_, _ = ui.Blue.Println("  - State directory check N/A on Windows (set BOSUN_STATE_DIR to enable)")
+		return CheckResult{}
+	}
 	stateDir := reconcile.DefaultStateDir
 	if dir := os.Getenv("BOSUN_STATE_DIR"); dir != "" {
 		stateDir = dir
@@ -237,7 +244,13 @@ func checkStateDir() CheckResult {
 // checkSocketDir verifies the directory that will hold the daemon Unix socket
 // is writable. The socket path defaults to daemon.DefaultSocketPath but is
 // overridden by BOSUN_SOCKET_PATH.
+// On Windows the daemon does not use Unix sockets at /var/run — the check
+// is skipped unless BOSUN_SOCKET_PATH overrides it with a valid path.
 func checkSocketDir() CheckResult {
+	if runtime.GOOS == "windows" && os.Getenv("BOSUN_SOCKET_PATH") == "" {
+		_, _ = ui.Blue.Println("  - Socket directory check N/A on Windows (set BOSUN_SOCKET_PATH to enable)")
+		return CheckResult{}
+	}
 	socketPath := "/var/run/bosun.sock"
 	if p := os.Getenv("BOSUN_SOCKET_PATH"); p != "" {
 		socketPath = p

--- a/internal/cmd/diagnostics_doctor.go
+++ b/internal/cmd/diagnostics_doctor.go
@@ -101,14 +101,26 @@ func checkProjectRoot(cfg *config.Config, loadErr error) CheckResult {
 		return CheckResult{Passed: 1}
 	}
 
-	// Distinguish a YAML parse/decode error from a missing-project error so
+	// Distinguish specific load failures from a missing-project situation so
 	// operators see the actual root cause rather than the generic "not found".
-	//
-	// yaml.v3 surfaces syntax errors as plain *errors.errorString (not
-	// *yaml.TypeError, which is reserved for type-mismatch). We detect the
-	// parse-failure case by checking the sentinel phrase that loadConfigFile
-	// embeds in its error message — this phrase is specific to bosun's own
-	// config loading and will not appear for other error conditions.
+
+	// File-read failure (e.g. permission denied on an existing config file).
+	// loadConfigFile embeds the sentinel "failed to read config file" — the
+	// project root was found but the file is unreadable.
+	if loadErr != nil && strings.Contains(loadErr.Error(), "failed to read config file") {
+		_, _ = ui.Red.Printf("  x Project config file unreadable: %s\n", loadErr)
+		_, _ = ui.Blue.Println("      To fix this:")
+		_, _ = ui.Blue.Println("      - Check file permissions: ls -l bosun.yaml")
+		_, _ = ui.Blue.Println("      - Fix permissions: chmod 644 bosun.yaml")
+		return CheckResult{Failed: 1}
+	}
+
+	// YAML parse/decode error. yaml.v3 surfaces syntax errors as plain
+	// *errors.errorString, not *yaml.TypeError. *yaml.TypeError is reserved
+	// for type-mismatch failures (e.g. a field declared as int receives a
+	// string), which can occur during struct decode after successful parsing.
+	// We keep both checks: the sentinel string for the common syntax case and
+	// errors.As for future type-mismatch paths.
 	var yamlTypeErr *yaml.TypeError
 	if loadErr != nil && (errors.As(loadErr, &yamlTypeErr) || strings.Contains(loadErr.Error(), "failed to parse config file")) {
 		_, _ = ui.Red.Printf("  x Project config invalid YAML: %s\n", loadErr)

--- a/internal/cmd/diagnostics_doctor.go
+++ b/internal/cmd/diagnostics_doctor.go
@@ -261,11 +261,17 @@ func checkSocketDir() CheckResult {
 }
 
 // webhookAddr returns the HTTP webhook host:port to probe.
-// It reads BOSUN_TCP_ADDR as the override (matching the daemon's env-var
-// precedence chain) and falls back to "localhost:8080".
+//
+// The HTTP webhook server (always-on, serves /health and /webhook) reads its
+// port from PORT first, then WEBHOOK_PORT as a legacy alias. This mirrors the
+// precedence chain in daemon.ConfigFromEnv. BOSUN_TCP_ADDR is unrelated — it
+// configures the opt-in TCP API server, which is a distinct service.
 func webhookAddr() string {
-	if addr := os.Getenv("BOSUN_TCP_ADDR"); addr != "" {
-		return addr
+	if port := os.Getenv("PORT"); port != "" {
+		return "localhost:" + port
+	}
+	if port := os.Getenv("WEBHOOK_PORT"); port != "" {
+		return "localhost:" + port
 	}
 	return "localhost:8080"
 }
@@ -287,7 +293,7 @@ func checkWebhook() CheckResult {
 	_, _ = ui.Blue.Println("      - Start bosun container: docker compose up -d bosun")
 	_, _ = ui.Blue.Println("      - Check logs: docker logs bosun")
 	_, _ = ui.Blue.Printf("      - Verify %s is available and not in use\n", addr)
-	_, _ = ui.Blue.Println("      - Set BOSUN_TCP_ADDR to override the default address")
+	_, _ = ui.Blue.Println("      - Set PORT (or WEBHOOK_PORT) to override the default port")
 	return CheckResult{Warned: 1}
 }
 

--- a/internal/cmd/diagnostics_doctor.go
+++ b/internal/cmd/diagnostics_doctor.go
@@ -12,10 +12,12 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"github.com/cameronsjo/bosun/internal/config"
 	"github.com/cameronsjo/bosun/internal/docker"
 	"github.com/cameronsjo/bosun/internal/preflight"
+	"github.com/cameronsjo/bosun/internal/reconcile"
 	"github.com/cameronsjo/bosun/internal/tunnel"
 	"github.com/cameronsjo/bosun/internal/ui"
 )
@@ -91,16 +93,36 @@ func checkGit() CheckResult {
 }
 
 // checkProjectRoot verifies the project root is accessible.
-func checkProjectRoot(cfg *config.Config) CheckResult {
+// loadErr is the error returned by config.Load(); when non-nil it is inspected
+// to distinguish a YAML parse failure from a plain "not found" situation.
+func checkProjectRoot(cfg *config.Config, loadErr error) CheckResult {
 	if cfg != nil {
 		_, _ = ui.Green.Printf("  * Project root found: %s\n", cfg.Root)
 		return CheckResult{Passed: 1}
 	}
+
+	// Distinguish a YAML parse/decode error from a missing-project error so
+	// operators see the actual root cause rather than the generic "not found".
+	//
+	// yaml.v3 surfaces syntax errors as plain *errors.errorString (not
+	// *yaml.TypeError, which is reserved for type-mismatch). We detect the
+	// parse-failure case by checking the sentinel phrase that loadConfigFile
+	// embeds in its error message — this phrase is specific to bosun's own
+	// config loading and will not appear for other error conditions.
+	var yamlTypeErr *yaml.TypeError
+	if loadErr != nil && (errors.As(loadErr, &yamlTypeErr) || strings.Contains(loadErr.Error(), "failed to parse config file")) {
+		_, _ = ui.Red.Printf("  x Project config invalid YAML: %s\n", loadErr)
+		_, _ = ui.Blue.Println("      To fix this:")
+		_, _ = ui.Blue.Println("      - Check bosun.yaml for syntax errors (tabs vs spaces, missing quotes, etc.)")
+		_, _ = ui.Blue.Println("      - Validate with: python3 -c \"import yaml,sys; yaml.safe_load(open('bosun.yaml'))\"")
+		return CheckResult{Failed: 1}
+	}
+
 	_, _ = ui.Yellow.Println("  ! Project root not found (run from project directory)")
 	_, _ = ui.Blue.Println("      To fix this:")
-	_, _ = ui.Blue.Println("      - Ensure config.yaml or manifest/ directory exists")
+	_, _ = ui.Blue.Println("      - Ensure bosun.yaml or manifest/ directory exists")
 	_, _ = ui.Blue.Println("      - Run bosun from the root of your project")
-	_, _ = ui.Blue.Println("      - Create config.yaml in project root if missing")
+	_, _ = ui.Blue.Println("      - Create bosun.yaml in project root if missing")
 	return CheckResult{Warned: 1}
 }
 
@@ -165,22 +187,107 @@ func checkManifestDirectory(cfg *config.Config) CheckResult {
 	return CheckResult{Warned: 1}
 }
 
+// checkStateDir verifies the deploy-state directory is writable.
+// The state dir defaults to reconcile.DefaultStateDir but is overridden by
+// the BOSUN_STATE_DIR environment variable (same logic as the daemon).
+func checkStateDir() CheckResult {
+	stateDir := reconcile.DefaultStateDir
+	if dir := os.Getenv("BOSUN_STATE_DIR"); dir != "" {
+		stateDir = dir
+	}
+
+	// Attempt to create the directory if it does not yet exist.
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		_, _ = ui.Red.Printf("  x State directory not writable: %s (%v)\n", stateDir, err)
+		_, _ = ui.Blue.Println("      To fix this:")
+		_, _ = ui.Blue.Printf("      - Create the directory: mkdir -p %s\n", stateDir)
+		_, _ = ui.Blue.Printf("      - Fix permissions: chmod 755 %s\n", stateDir)
+		_, _ = ui.Blue.Println("      - Or set BOSUN_STATE_DIR to a writable path")
+		return CheckResult{Failed: 1}
+	}
+
+	// Probe write access with a temp file.
+	probe, err := os.CreateTemp(stateDir, ".bosun-doctor-probe-*")
+	if err != nil {
+		_, _ = ui.Red.Printf("  x State directory not writable: %s (%v)\n", stateDir, err)
+		_, _ = ui.Blue.Println("      To fix this:")
+		_, _ = ui.Blue.Printf("      - Fix permissions: chmod 755 %s\n", stateDir)
+		_, _ = ui.Blue.Println("      - Or set BOSUN_STATE_DIR to a writable path")
+		return CheckResult{Failed: 1}
+	}
+	_ = probe.Close()
+	_ = os.Remove(probe.Name())
+
+	_, _ = ui.Green.Printf("  * State directory writable: %s\n", stateDir)
+	return CheckResult{Passed: 1}
+}
+
+// checkSocketDir verifies the directory that will hold the daemon Unix socket
+// is writable. The socket path defaults to daemon.DefaultSocketPath but is
+// overridden by BOSUN_SOCKET_PATH.
+func checkSocketDir() CheckResult {
+	socketPath := "/var/run/bosun.sock"
+	if p := os.Getenv("BOSUN_SOCKET_PATH"); p != "" {
+		socketPath = p
+	}
+	socketDir := filepath.Dir(socketPath)
+
+	if err := os.MkdirAll(socketDir, 0755); err != nil {
+		_, _ = ui.Red.Printf("  x Socket directory not writable: %s (%v)\n", socketDir, err)
+		_, _ = ui.Blue.Println("      To fix this:")
+		_, _ = ui.Blue.Printf("      - Create the directory: sudo mkdir -p %s\n", socketDir)
+		_, _ = ui.Blue.Printf("      - Fix permissions: sudo chmod 755 %s\n", socketDir)
+		_, _ = ui.Blue.Println("      - Or set BOSUN_SOCKET_PATH to a path in a writable directory")
+		return CheckResult{Failed: 1}
+	}
+
+	// Probe write access — only test if the socket doesn't already exist
+	// (an existing socket means the daemon is live, which is fine).
+	if _, err := os.Stat(socketPath); os.IsNotExist(err) {
+		probe, err := os.CreateTemp(socketDir, ".bosun-doctor-probe-*")
+		if err != nil {
+			_, _ = ui.Red.Printf("  x Socket directory not writable: %s (%v)\n", socketDir, err)
+			_, _ = ui.Blue.Println("      To fix this:")
+			_, _ = ui.Blue.Printf("      - Fix permissions: sudo chmod 755 %s\n", socketDir)
+			_, _ = ui.Blue.Println("      - Or set BOSUN_SOCKET_PATH to a path in a writable directory")
+			return CheckResult{Failed: 1}
+		}
+		_ = probe.Close()
+		_ = os.Remove(probe.Name())
+	}
+
+	_, _ = ui.Green.Printf("  * Socket directory writable: %s\n", socketDir)
+	return CheckResult{Passed: 1}
+}
+
+// webhookAddr returns the HTTP webhook host:port to probe.
+// It reads BOSUN_TCP_ADDR as the override (matching the daemon's env-var
+// precedence chain) and falls back to "localhost:8080".
+func webhookAddr() string {
+	if addr := os.Getenv("BOSUN_TCP_ADDR"); addr != "" {
+		return addr
+	}
+	return "localhost:8080"
+}
+
 // checkWebhook verifies the webhook endpoint is responding.
 func checkWebhook() CheckResult {
+	addr := webhookAddr()
 	httpClient := &http.Client{Timeout: httpClientTimeout}
-	resp, err := httpClient.Get("http://localhost:8080/health")
+	resp, err := httpClient.Get("http://" + addr + "/health")
 	if err == nil {
 		_ = resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
-			_, _ = ui.Green.Println("  * Webhook endpoint responding")
+			_, _ = ui.Green.Printf("  * Webhook endpoint responding (%s)\n", addr)
 			return CheckResult{Passed: 1}
 		}
 	}
-	_, _ = ui.Yellow.Println("  ! Webhook not responding (bosun container not running?)")
+	_, _ = ui.Yellow.Printf("  ! Webhook not responding at %s (bosun container not running?)\n", addr)
 	_, _ = ui.Blue.Println("      To fix this:")
 	_, _ = ui.Blue.Println("      - Start bosun container: docker compose up -d bosun")
 	_, _ = ui.Blue.Println("      - Check logs: docker logs bosun")
-	_, _ = ui.Blue.Println("      - Verify port 8080 is available and not in use")
+	_, _ = ui.Blue.Printf("      - Verify %s is available and not in use\n", addr)
+	_, _ = ui.Blue.Println("      - Set BOSUN_TCP_ADDR to override the default address")
 	return CheckResult{Warned: 1}
 }
 
@@ -378,8 +485,9 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 	var result CheckResult
 
-	// Load config once for checks that need it
-	cfg, _ := config.Load()
+	// Load config once for checks that need it; preserve the error so
+	// checkProjectRoot can distinguish a YAML parse failure from "not found".
+	cfg, cfgErr := config.Load()
 
 	// Run all checks with timeout context for Docker
 	ctx, cancel := context.WithTimeout(context.Background(), dockerPingTimeout)
@@ -389,10 +497,12 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	result.Add(checkDockerCompose())
 	result.Add(checkGit())
 	result.Add(checkDeployKeyPermissions())
-	result.Add(checkProjectRoot(cfg))
+	result.Add(checkProjectRoot(cfg, cfgErr))
 	result.Add(checkAgeKey())
 	result.Add(checkSOPS())
 	result.Add(checkManifestDirectory(cfg))
+	result.Add(checkStateDir())
+	result.Add(checkSocketDir())
 	result.Add(checkWebhook())
 
 	// Check tunnel provider with timeout

--- a/internal/cmd/diagnostics_doctor_test.go
+++ b/internal/cmd/diagnostics_doctor_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -348,4 +349,30 @@ func TestCheckWebhook_UsesEnvAddr(t *testing.T) {
 	assert.Equal(t, 0, result.Passed)
 	assert.Equal(t, 1, result.Warned)
 	assert.Equal(t, 0, result.Failed)
+}
+
+func TestCheckSocketDir_WindowsSkip(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only: verifies early return when no override is set")
+	}
+	// On Windows with no BOSUN_SOCKET_PATH, checkSocketDir must return an empty
+	// result (not a failure) — /var/run/bosun.sock is meaningless on Windows.
+	t.Setenv("BOSUN_SOCKET_PATH", "")
+	result := checkSocketDir()
+	assert.Equal(t, 0, result.Passed)
+	assert.Equal(t, 0, result.Failed)
+	assert.Equal(t, 0, result.Warned)
+}
+
+func TestCheckStateDir_WindowsSkip(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only: verifies early return when no override is set")
+	}
+	// On Windows with no BOSUN_STATE_DIR, checkStateDir must return an empty
+	// result (not a failure) — /var/lib/bosun is meaningless on Windows.
+	t.Setenv("BOSUN_STATE_DIR", "")
+	result := checkStateDir()
+	assert.Equal(t, 0, result.Passed)
+	assert.Equal(t, 0, result.Failed)
+	assert.Equal(t, 0, result.Warned)
 }

--- a/internal/cmd/diagnostics_doctor_test.go
+++ b/internal/cmd/diagnostics_doctor_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -376,3 +379,111 @@ func TestCheckStateDir_WindowsSkip(t *testing.T) {
 	assert.Equal(t, 0, result.Failed)
 	assert.Equal(t, 0, result.Warned)
 }
+
+// TestCheckStateDir_UnwritableAfterMkdirAll covers the CreateTemp error branch:
+// MkdirAll succeeds but the directory is not writable for temp-file creation.
+func TestCheckStateDir_UnwritableAfterMkdirAll(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod semantics differ on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("cannot test permission denial as root")
+	}
+
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, "state")
+	require.NoError(t, os.MkdirAll(stateDir, 0755))
+
+	// Remove write bit so CreateTemp fails while MkdirAll (which is a no-op
+	// for an existing dir) succeeds.
+	require.NoError(t, os.Chmod(stateDir, 0555))
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0755) })
+
+	t.Setenv("BOSUN_STATE_DIR", stateDir)
+	result := checkStateDir()
+	assert.Equal(t, 1, result.Failed)
+	assert.Equal(t, 0, result.Passed)
+}
+
+// TestCheckSocketDir_UnwritableAfterMkdirAll covers the CreateTemp error branch
+// inside the os.IsNotExist guard: the directory exists but is not writable.
+func TestCheckSocketDir_UnwritableAfterMkdirAll(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod semantics differ on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("cannot test permission denial as root")
+	}
+
+	tmpDir := t.TempDir()
+	socketDir := filepath.Join(tmpDir, "run")
+	require.NoError(t, os.MkdirAll(socketDir, 0755))
+
+	// Remove write bit so CreateTemp inside the os.IsNotExist branch fails.
+	require.NoError(t, os.Chmod(socketDir, 0555))
+	t.Cleanup(func() { _ = os.Chmod(socketDir, 0755) })
+
+	t.Setenv("BOSUN_SOCKET_PATH", filepath.Join(socketDir, "bosun.sock"))
+	result := checkSocketDir()
+	assert.Equal(t, 1, result.Failed)
+	assert.Equal(t, 0, result.Passed)
+}
+
+// TestCheckSocketDir_SocketAlreadyExists covers the branch where the socket
+// file already exists (daemon is live). The write probe is skipped and the
+// check should pass.
+func TestCheckSocketDir_SocketAlreadyExists(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix socket semantics differ on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "bosun.sock")
+
+	// Create a placeholder file to simulate an existing socket.
+	require.NoError(t, os.WriteFile(socketPath, []byte{}, 0600))
+
+	t.Setenv("BOSUN_SOCKET_PATH", socketPath)
+	result := checkSocketDir()
+	assert.Equal(t, 1, result.Passed)
+	assert.Equal(t, 0, result.Failed)
+}
+
+// TestCheckWebhook_Responding covers the success branch: webhook returns 200 OK.
+func TestCheckWebhook_Responding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	// Extract port from the test server address (host:port).
+	_, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+	t.Setenv("PORT", port)
+	t.Setenv("WEBHOOK_PORT", "")
+
+	result := checkWebhook()
+	assert.Equal(t, 1, result.Passed)
+	assert.Equal(t, 0, result.Warned)
+	assert.Equal(t, 0, result.Failed)
+}
+
+// TestCheckWebhook_NonOKStatus covers the branch where the server responds but
+// returns a non-200 status — should warn, not pass.
+func TestCheckWebhook_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+	t.Setenv("PORT", port)
+	t.Setenv("WEBHOOK_PORT", "")
+
+	result := checkWebhook()
+	assert.Equal(t, 0, result.Passed)
+	assert.Equal(t, 1, result.Warned)
+	assert.Equal(t, 0, result.Failed)
+}
+

--- a/internal/cmd/diagnostics_doctor_test.go
+++ b/internal/cmd/diagnostics_doctor_test.go
@@ -44,17 +44,41 @@ func TestCheckProjectRoot(t *testing.T) {
 		cfg := &config.Config{
 			Root: "/some/path",
 		}
-		result := checkProjectRoot(cfg)
+		result := checkProjectRoot(cfg, nil)
 		assert.Equal(t, 1, result.Passed)
 		assert.Equal(t, 0, result.Failed)
 		assert.Equal(t, 0, result.Warned)
 	})
 
-	t.Run("with nil config", func(t *testing.T) {
-		result := checkProjectRoot(nil)
+	t.Run("with nil config and no error", func(t *testing.T) {
+		result := checkProjectRoot(nil, nil)
 		assert.Equal(t, 0, result.Passed)
 		assert.Equal(t, 0, result.Failed)
 		assert.Equal(t, 1, result.Warned)
+	})
+
+	t.Run("with nil config and YAML parse error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// Write a syntactically invalid bosun.yaml
+		bosunYAML := filepath.Join(tmpDir, "bosun.yaml")
+		require.NoError(t, os.WriteFile(bosunYAML, []byte("key: [unclosed"), 0644))
+
+		// Also create a manifest dir so FindRoot anchors here
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "manifest"), 0755))
+
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() { _ = os.Chdir(originalWd) }()
+		require.NoError(t, os.Chdir(tmpDir))
+
+		_, loadErr := config.Load()
+		require.Error(t, loadErr)
+
+		result := checkProjectRoot(nil, loadErr)
+		// YAML parse errors must be surfaced as failures, not generic warnings.
+		assert.Equal(t, 1, result.Failed, "YAML parse error should be a failure")
+		assert.Equal(t, 0, result.Warned)
+		assert.Equal(t, 0, result.Passed)
 	})
 }
 
@@ -224,4 +248,61 @@ func TestCheckTraefikConfig(t *testing.T) {
 		assert.Equal(t, 0, result.Passed)
 		assert.Equal(t, 4, result.Warned)
 	})
+}
+
+func TestCheckStateDir(t *testing.T) {
+	t.Run("writable custom dir via BOSUN_STATE_DIR", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("BOSUN_STATE_DIR", tmpDir)
+		result := checkStateDir()
+		assert.Equal(t, 1, result.Passed)
+		assert.Equal(t, 0, result.Failed)
+	})
+
+	t.Run("non-writable dir fails", func(t *testing.T) {
+		// Point to a path under a non-existent root that cannot be created.
+		t.Setenv("BOSUN_STATE_DIR", "/proc/bosun-cannot-create-this")
+		result := checkStateDir()
+		assert.Equal(t, 1, result.Failed)
+		assert.Equal(t, 0, result.Passed)
+	})
+}
+
+func TestCheckSocketDir(t *testing.T) {
+	t.Run("writable custom socket path via BOSUN_SOCKET_PATH", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("BOSUN_SOCKET_PATH", filepath.Join(tmpDir, "bosun.sock"))
+		result := checkSocketDir()
+		assert.Equal(t, 1, result.Passed)
+		assert.Equal(t, 0, result.Failed)
+	})
+
+	t.Run("non-writable socket dir fails", func(t *testing.T) {
+		t.Setenv("BOSUN_SOCKET_PATH", "/proc/bosun-cannot-create-this/bosun.sock")
+		result := checkSocketDir()
+		assert.Equal(t, 1, result.Failed)
+		assert.Equal(t, 0, result.Passed)
+	})
+}
+
+func TestWebhookAddr(t *testing.T) {
+	t.Run("defaults to localhost:8080", func(t *testing.T) {
+		t.Setenv("BOSUN_TCP_ADDR", "")
+		assert.Equal(t, "localhost:8080", webhookAddr())
+	})
+
+	t.Run("reads BOSUN_TCP_ADDR", func(t *testing.T) {
+		t.Setenv("BOSUN_TCP_ADDR", "192.168.1.10:9090")
+		assert.Equal(t, "192.168.1.10:9090", webhookAddr())
+	})
+}
+
+func TestCheckWebhook_UsesEnvAddr(t *testing.T) {
+	// Point at a port that is definitely not listening to confirm the address
+	// is respected (the check should warn, not panic or use a wrong address).
+	t.Setenv("BOSUN_TCP_ADDR", "127.0.0.1:19999")
+	result := checkWebhook()
+	assert.Equal(t, 0, result.Passed)
+	assert.Equal(t, 1, result.Warned)
+	assert.Equal(t, 0, result.Failed)
 }

--- a/internal/cmd/diagnostics_doctor_test.go
+++ b/internal/cmd/diagnostics_doctor_test.go
@@ -80,6 +80,34 @@ func TestCheckProjectRoot(t *testing.T) {
 		assert.Equal(t, 0, result.Warned)
 		assert.Equal(t, 0, result.Passed)
 	})
+
+	t.Run("with nil config and file-read error", func(t *testing.T) {
+		if os.Getuid() == 0 {
+			t.Skip("cannot test permission denial as root")
+		}
+		tmpDir := t.TempDir()
+		bosunYAML := filepath.Join(tmpDir, "bosun.yaml")
+		require.NoError(t, os.WriteFile(bosunYAML, []byte("{}"), 0644))
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "manifest"), 0755))
+		// Make the file unreadable so loadConfigFile returns a read error.
+		require.NoError(t, os.Chmod(bosunYAML, 0000))
+		defer func() { _ = os.Chmod(bosunYAML, 0644) }()
+
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() { _ = os.Chdir(originalWd) }()
+		require.NoError(t, os.Chdir(tmpDir))
+
+		_, loadErr := config.Load()
+		require.Error(t, loadErr)
+
+		result := checkProjectRoot(nil, loadErr)
+		// File-read errors must be surfaced as failures with a distinct message,
+		// not the generic "project root not found" warning.
+		assert.Equal(t, 1, result.Failed, "file-read error should be a failure")
+		assert.Equal(t, 0, result.Warned)
+		assert.Equal(t, 0, result.Passed)
+	})
 }
 
 func TestCheckAgeKey(t *testing.T) {

--- a/internal/cmd/diagnostics_doctor_test.go
+++ b/internal/cmd/diagnostics_doctor_test.go
@@ -287,20 +287,35 @@ func TestCheckSocketDir(t *testing.T) {
 
 func TestWebhookAddr(t *testing.T) {
 	t.Run("defaults to localhost:8080", func(t *testing.T) {
-		t.Setenv("BOSUN_TCP_ADDR", "")
+		t.Setenv("PORT", "")
+		t.Setenv("WEBHOOK_PORT", "")
 		assert.Equal(t, "localhost:8080", webhookAddr())
 	})
 
-	t.Run("reads BOSUN_TCP_ADDR", func(t *testing.T) {
-		t.Setenv("BOSUN_TCP_ADDR", "192.168.1.10:9090")
-		assert.Equal(t, "192.168.1.10:9090", webhookAddr())
+	t.Run("reads PORT", func(t *testing.T) {
+		t.Setenv("PORT", "9080")
+		t.Setenv("WEBHOOK_PORT", "")
+		assert.Equal(t, "localhost:9080", webhookAddr())
+	})
+
+	t.Run("reads WEBHOOK_PORT as legacy alias", func(t *testing.T) {
+		t.Setenv("PORT", "")
+		t.Setenv("WEBHOOK_PORT", "9081")
+		assert.Equal(t, "localhost:9081", webhookAddr())
+	})
+
+	t.Run("PORT takes precedence over WEBHOOK_PORT", func(t *testing.T) {
+		t.Setenv("PORT", "9080")
+		t.Setenv("WEBHOOK_PORT", "9081")
+		assert.Equal(t, "localhost:9080", webhookAddr())
 	})
 }
 
 func TestCheckWebhook_UsesEnvAddr(t *testing.T) {
 	// Point at a port that is definitely not listening to confirm the address
 	// is respected (the check should warn, not panic or use a wrong address).
-	t.Setenv("BOSUN_TCP_ADDR", "127.0.0.1:19999")
+	t.Setenv("PORT", "19999")
+	t.Setenv("WEBHOOK_PORT", "")
 	result := checkWebhook()
 	assert.Equal(t, 0, result.Passed)
 	assert.Equal(t, 1, result.Warned)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,6 +284,18 @@ func FindRoot() (string, error) {
 	}
 
 	homeDir, _ := os.UserHomeDir()
+	// Normalize $HOME for comparison: os.Getwd() returns a symlink-resolved
+	// path on most platforms (macOS returns /private/var/... not /var/...),
+	// but os.UserHomeDir() returns the raw $HOME value. Without normalization
+	// the equality check in the weak-marker guard never fires when $HOME
+	// contains symlink components. If EvalSymlinks fails (deleted dir,
+	// permission issue), skip normalization and proceed — the guard may miss
+	// an edge case but the caller is not harmed.
+	if homeDir != "" {
+		if resolved, err := filepath.EvalSymlinks(homeDir); err == nil {
+			homeDir = resolved
+		}
+	}
 
 	for dir != "/" {
 		// Check for bosun.yaml or bosun.yml config file (strong marker — always accepted).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,15 +270,23 @@ type configFile struct {
 // The project root is identified by:
 // - bosun.yaml or bosun.yml config file
 // - bosun/ directory with docker-compose.yml
-// - manifest/ or manifests/ directory
+// - manifest/ or manifests/ directory (not accepted when candidate dir is $HOME)
+//
+// When the only matching marker in a candidate directory is manifest/ or manifests/
+// and that directory equals the user's home directory, FindRoot refuses to anchor
+// there. Generic directory names like "manifest/" are common in npm projects, OCI
+// tooling, and packaging pipelines; anchoring bosun to $HOME on their presence
+// would cause it to operate on the wrong directory silently.
 func FindRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get working directory: %w", err)
 	}
 
+	homeDir, _ := os.UserHomeDir()
+
 	for dir != "/" {
-		// Check for bosun.yaml or bosun.yml config file
+		// Check for bosun.yaml or bosun.yml config file (strong marker — always accepted).
 		for _, name := range []string{"bosun.yaml", "bosun.yml"} {
 			configPath := filepath.Join(dir, name)
 			if _, err := os.Stat(configPath); err == nil {
@@ -286,7 +294,7 @@ func FindRoot() (string, error) {
 			}
 		}
 
-		// Check for bosun directory with docker-compose.yml
+		// Check for bosun/ directory with docker-compose.yml (strong marker — always accepted).
 		bosunDir := filepath.Join(dir, "bosun")
 		if info, err := os.Stat(bosunDir); err == nil && info.IsDir() {
 			composeFile := filepath.Join(bosunDir, "docker-compose.yml")
@@ -295,11 +303,15 @@ func FindRoot() (string, error) {
 			}
 		}
 
-		// Check for manifest or manifests directory
-		for _, name := range []string{"manifest", "manifests"} {
-			manifestDir := filepath.Join(dir, name)
-			if info, err := os.Stat(manifestDir); err == nil && info.IsDir() {
-				return dir, nil
+		// Check for manifest/ or manifests/ directory (weak marker).
+		// Refuse to anchor on these alone when the candidate directory is $HOME —
+		// these names are too generic and collide with unrelated tooling.
+		if homeDir == "" || dir != homeDir {
+			for _, name := range []string{"manifest", "manifests"} {
+				manifestDir := filepath.Join(dir, name)
+				if info, err := os.Stat(manifestDir); err == nil && info.IsDir() {
+					return dir, nil
+				}
 			}
 		}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -112,6 +112,67 @@ func TestFindRoot_NoProjectRoot(t *testing.T) {
 	assert.Contains(t, err.Error(), "project root not found")
 }
 
+// TestFindRoot_RefusesHomeAnchorOnManifestOnly verifies that FindRoot does not
+// anchor to $HOME when the only marker present is a manifest/ or manifests/
+// directory. These directory names are too generic; npm, OCI tooling, and
+// packaging pipelines all use them.
+func TestFindRoot_RefusesHomeAnchorOnManifestOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME env var semantics differ on Windows")
+	}
+
+	// Use a temp dir as the fake home so we don't pollute the real $HOME.
+	fakeHome := evalSymlinks(t, t.TempDir())
+	t.Setenv("HOME", fakeHome)
+
+	// Place only a manifest/ directory inside fake $HOME — no bosun.yaml or bosun/.
+	require.NoError(t, os.MkdirAll(filepath.Join(fakeHome, "manifest"), 0755))
+
+	// Create a project subdirectory and cd into it, so FindRoot walks up to fakeHome.
+	subDir := filepath.Join(fakeHome, "projects", "myapp")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(originalWd) }()
+	require.NoError(t, os.Chdir(subDir))
+
+	// FindRoot must refuse to anchor on manifest/ inside $HOME.
+	_, err = FindRoot()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project root not found")
+}
+
+// TestFindRoot_AcceptsHomeAnchorWithStrongMarker verifies that a bosun.yaml
+// directly in $HOME is still accepted — only the weak manifest/ marker is
+// refused at $HOME.
+func TestFindRoot_AcceptsHomeAnchorWithStrongMarker(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME env var semantics differ on Windows")
+	}
+
+	fakeHome := evalSymlinks(t, t.TempDir())
+	t.Setenv("HOME", fakeHome)
+
+	// Place bosun.yaml in fake $HOME — strong marker.
+	require.NoError(t, os.WriteFile(filepath.Join(fakeHome, "bosun.yaml"), []byte("{}"), 0644))
+	// Also add a manifest/ directory to confirm both can coexist.
+	require.NoError(t, os.MkdirAll(filepath.Join(fakeHome, "manifest"), 0755))
+
+	subDir := filepath.Join(fakeHome, "projects", "myapp")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(originalWd) }()
+	require.NoError(t, os.Chdir(subDir))
+
+	// FindRoot must succeed because bosun.yaml is present.
+	root, err := FindRoot()
+	require.NoError(t, err)
+	assert.Equal(t, fakeHome, root)
+}
+
 func TestFindRoot_FromProjectRoot(t *testing.T) {
 	tmpDir := evalSymlinks(t, t.TempDir())
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -173,6 +173,43 @@ func TestFindRoot_AcceptsHomeAnchorWithStrongMarker(t *testing.T) {
 	assert.Equal(t, fakeHome, root)
 }
 
+// TestFindRoot_RefusesHomeAnchorThroughSymlink verifies that the $HOME guard
+// still fires when $HOME contains a symlink component. os.UserHomeDir() returns
+// the raw $HOME value without resolving symlinks, while os.Getwd() returns the
+// resolved path — without EvalSymlinks normalization the equality check misses.
+func TestFindRoot_RefusesHomeAnchorThroughSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	// Create a real directory to act as the symlink target.
+	realHome := evalSymlinks(t, t.TempDir())
+	// Create a symlink that points at realHome.
+	symlinkHome := filepath.Join(t.TempDir(), "symlinked-home")
+	require.NoError(t, os.Symlink(realHome, symlinkHome))
+
+	// Set HOME to the symlink path (raw, unresolved).
+	t.Setenv("HOME", symlinkHome)
+
+	// Place only a manifest/ directory inside the real target — no bosun.yaml.
+	require.NoError(t, os.MkdirAll(filepath.Join(realHome, "manifest"), 0755))
+
+	// cd into a subdirectory so FindRoot walks up through the symlinked home.
+	subDir := filepath.Join(realHome, "projects", "myapp")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(originalWd) }()
+	require.NoError(t, os.Chdir(subDir))
+
+	// FindRoot must refuse to anchor on manifest/ inside $HOME even when $HOME
+	// is a symlink and the resolved path is what dir reaches.
+	_, err = FindRoot()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project root not found")
+}
+
 func TestFindRoot_FromProjectRoot(t *testing.T) {
 	tmpDir := evalSymlinks(t, t.TempDir())
 


### PR DESCRIPTION
## Summary

- **GH #288** — `FindRoot` no longer anchors on `manifest/` or `manifests/` alone when the candidate directory equals `$HOME`. Generic directory names like `manifest/` collide with npm, OCI, and packaging pipelines; the fix requires a strong marker (`bosun.yaml`, `bosun.yml`, or `bosun/` with `docker-compose.yml`) at `$HOME`. Elsewhere the existing logic is unchanged.

- **GH #261** — `bosun doctor` previously discarded the error from `config.Load()` and always showed the generic "project root not found" warning. The load error is now forwarded to `checkProjectRoot`, which distinguishes a YAML parse failure (detected by the sentinel phrase `"failed to parse config file"` that `loadConfigFile` embeds) from a plain missing-project error. YAML errors are now reported as failures with targeted remediation hints.

- **GH #262** — Three additions to `bosun doctor`:
  - `checkStateDir()` verifies the deploy-state directory (`/var/lib/bosun` or `BOSUN_STATE_DIR`) exists and is writable.
  - `checkSocketDir()` verifies the parent directory of the daemon Unix socket (`/var/run` or `BOSUN_SOCKET_PATH`) is writable.
  - `checkWebhook()` now reads `BOSUN_TCP_ADDR` and falls back to `localhost:8080` instead of hardcoding the address.

Closes #261, #262, #288

## Test plan

- [ ] `go test ./internal/config/...` — new `TestFindRoot_RefusesHomeAnchorOnManifestOnly` and `TestFindRoot_AcceptsHomeAnchorWithStrongMarker` pass
- [ ] `go test ./internal/cmd/... -run TestCheckProjectRoot` — YAML parse error case reports `Failed: 1`
- [ ] `go test ./internal/cmd/... -run "TestCheckStateDir|TestCheckSocketDir|TestWebhookAddr|TestCheckWebhook"` — all pass
- [ ] `go test ./...` — full suite passes (exit 0)
- [ ] `make build` — binary builds cleanly
- [ ] Smoke: `mkdir /tmp/fake-home && mkdir /tmp/fake-home/manifest && mkdir /tmp/fake-home/myapp && cd /tmp/fake-home/myapp && HOME=/tmp/fake-home bosun doctor` shows "Project root not found" and does NOT silently operate on `/tmp/fake-home`

🤖 Generated with [Claude Code](https://claude.com/claude-code)