### PR TITLE
fix: centralize BOSUN_X env-var precedence (Cluster G)

### DIFF
--- a/internal/cmd/breaker.go
+++ b/internal/cmd/breaker.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cameronsjo/bosun/internal/reconcile"
+	"github.com/cameronsjo/bosun/internal/ui"
+)
+
+var (
+	breakerStateDir string
+	breakerTarget   string
+)
+
+// breakerCmd is the parent command for circuit breaker operations.
+var breakerCmd = &cobra.Command{
+	Use:   "breaker",
+	Short: "Manage the deploy circuit breaker",
+	Long: `View and manage the deploy circuit breaker state.
+
+The circuit breaker trips after 3 consecutive deploy failures on the same
+commit, preventing infinite retry loops. Use these commands to inspect
+the breaker state and reset it when the root cause has been resolved.`,
+}
+
+// breakerStatusCmd shows circuit breaker state.
+var breakerStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show circuit breaker state",
+	RunE:  runBreakerStatus,
+}
+
+// breakerResetCmd resets the circuit breaker.
+var breakerResetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Reset the circuit breaker to allow retries",
+	Long: `Reset the deploy circuit breaker by clearing the failure counter.
+
+This allows reconciliation to retry after the breaker has tripped.
+Use this after resolving the root cause of deploy failures.`,
+	RunE: runBreakerReset,
+}
+
+func init() {
+	breakerCmd.PersistentFlags().StringVar(&breakerStateDir, "state-dir", reconcile.DefaultStateDir, "State directory")
+	breakerCmd.PersistentFlags().StringVarP(&breakerTarget, "target", "t", "", "Named deployment target (from bosun.yaml targets: section)")
+
+	breakerCmd.AddCommand(breakerStatusCmd)
+	breakerCmd.AddCommand(breakerResetCmd)
+	rootCmd.AddCommand(breakerCmd)
+}
+
+// resolveBreaker StateFile returns the state file for the active target, honoring
+// the --target flag (and BOSUN_STATE_DIR override) in the same way that
+// bosun drift does.
+func resolveBreakerStateFile() string {
+	dir := breakerStateDir
+	if d := os.Getenv("BOSUN_STATE_DIR"); d != "" {
+		dir = d
+	}
+
+	if breakerTarget != "" {
+		targets := loadConfiguredTargets()
+		for _, t := range targets {
+			if t.Name == breakerTarget {
+				return reconcile.TargetStateFile(dir, t)
+			}
+		}
+		// Target not in config — still derive the state file by name.
+		t := reconcile.Target{Name: breakerTarget}
+		return reconcile.TargetStateFile(dir, t)
+	}
+
+	return filepath.Join(dir, reconcile.DefaultStateFile)
+}
+
+func runBreakerStatus(cmd *cobra.Command, args []string) error {
+	stateFile := resolveBreakerStateFile()
+	state := reconcile.LoadState(stateFile)
+
+	if breakerTarget != "" {
+		ui.Header("Target: %s", breakerTarget)
+	}
+
+	if state.AttemptCount == 0 {
+		ui.Success("Circuit breaker: closed (no failures)")
+		return nil
+	}
+
+	if state.AttemptCount >= reconcile.MaxAttempts {
+		ui.Error("Circuit breaker: OPEN (%d consecutive failures on %s)",
+			state.AttemptCount, truncateCommit(state.LastAttemptedCommit))
+		ui.Info("  Run 'bosun breaker reset' to allow retries")
+		return nil
+	}
+
+	ui.Warning("Circuit breaker: closed (%d/%d failures on %s)",
+		state.AttemptCount, reconcile.MaxAttempts, truncateCommit(state.LastAttemptedCommit))
+	return nil
+}
+
+func runBreakerReset(cmd *cobra.Command, args []string) error {
+	stateFile := resolveBreakerStateFile()
+	state := reconcile.LoadState(stateFile)
+
+	if breakerTarget != "" {
+		ui.Header("Target: %s", breakerTarget)
+	}
+
+	if state.AttemptCount == 0 {
+		ui.Info("Circuit breaker already closed, nothing to reset")
+		return nil
+	}
+
+	priorAttempts := state.AttemptCount
+	priorCommit := state.LastAttemptedCommit
+
+	state.AttemptCount = 0
+	state.LastAttemptedCommit = ""
+	state.LastAlertedAttempt = 0
+
+	if err := reconcile.SaveState(stateFile, state); err != nil {
+		return fmt.Errorf("failed to save state: %w", err)
+	}
+
+	ui.Success("Circuit breaker reset (was: %d failures on %s)",
+		priorAttempts, truncateCommit(priorCommit))
+	return nil
+}
+
+func truncateCommit(hash string) string {
+	if len(hash) > 7 {
+		return hash[:7]
+	}
+	return hash
+}

--- a/internal/cmd/breaker.go
+++ b/internal/cmd/breaker.go
@@ -24,7 +24,15 @@ var breakerCmd = &cobra.Command{
 
 The circuit breaker trips after 3 consecutive deploy failures on the same
 commit, preventing infinite retry loops. Use these commands to inspect
-the breaker state and reset it when the root cause has been resolved.`,
+the breaker state and reset it when the root cause has been resolved.
+
+State directory resolution:
+  The --state-dir flag sets the base directory for state files. If the
+  BOSUN_STATE_DIR environment variable is set, it overrides --state-dir
+  at runtime (same precedence pattern as other BOSUN_ env vars).
+
+  Note: 'bosun drift --state-file' uses an explicit file path and does NOT
+  honour BOSUN_STATE_DIR. Unifying this behaviour is tracked as a follow-up.`,
 }
 
 // breakerStatusCmd shows circuit breaker state.

--- a/internal/cmd/breaker_test.go
+++ b/internal/cmd/breaker_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cameronsjo/bosun/internal/reconcile"
+)
+
+func TestBreakerCmd_Registration(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"breaker"})
+	require.NoError(t, err)
+	assert.Equal(t, "breaker", cmd.Name())
+}
+
+func TestBreakerCmd_HasTargetFlag(t *testing.T) {
+	flag := breakerCmd.PersistentFlags().Lookup("target")
+	require.NotNil(t, flag, "--target flag should be registered on breaker command")
+	assert.Equal(t, "t", flag.Shorthand)
+}
+
+func TestBreakerStatusCmd_Registration(t *testing.T) {
+	cmd, _, err := breakerCmd.Find([]string{"status"})
+	require.NoError(t, err)
+	assert.Equal(t, "status", cmd.Name())
+}
+
+func TestBreakerResetCmd_Registration(t *testing.T) {
+	cmd, _, err := breakerCmd.Find([]string{"reset"})
+	require.NoError(t, err)
+	assert.Equal(t, "reset", cmd.Name())
+}
+
+func TestResolveBreakerStateFile_Default(t *testing.T) {
+	t.Setenv("BOSUN_STATE_DIR", "")
+
+	// Reset flag state to avoid cross-test pollution.
+	orig := breakerTarget
+	breakerTarget = ""
+	defer func() { breakerTarget = orig }()
+
+	origDir := breakerStateDir
+	breakerStateDir = "/var/lib/bosun"
+	defer func() { breakerStateDir = origDir }()
+
+	got := resolveBreakerStateFile()
+	assert.Equal(t, filepath.Join("/var/lib/bosun", reconcile.DefaultStateFile), got)
+}
+
+func TestResolveBreakerStateFile_WithTarget(t *testing.T) {
+	t.Setenv("BOSUN_STATE_DIR", "")
+
+	orig := breakerTarget
+	breakerTarget = "unraid"
+	defer func() { breakerTarget = orig }()
+
+	origDir := breakerStateDir
+	breakerStateDir = "/var/lib/bosun"
+	defer func() { breakerStateDir = origDir }()
+
+	got := resolveBreakerStateFile()
+	// Named target should produce deploy-state-<name>.json
+	assert.Equal(t, filepath.Join("/var/lib/bosun", "deploy-state-unraid.json"), got)
+}
+
+func TestResolveBreakerStateFile_StateDirEnvVar(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("BOSUN_STATE_DIR", tmpDir)
+
+	orig := breakerTarget
+	breakerTarget = ""
+	defer func() { breakerTarget = orig }()
+
+	got := resolveBreakerStateFile()
+	assert.Equal(t, filepath.Join(tmpDir, reconcile.DefaultStateFile), got)
+}
+
+func TestBreakerStatus_ClosedBreaker(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("BOSUN_STATE_DIR", tmpDir)
+
+	orig := breakerTarget
+	breakerTarget = ""
+	defer func() { breakerTarget = orig }()
+
+	// No state file — breaker should report closed.
+	err := runBreakerStatus(breakerStatusCmd, nil)
+	require.NoError(t, err)
+}
+
+func TestBreakerReset_NothingToReset(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("BOSUN_STATE_DIR", tmpDir)
+
+	orig := breakerTarget
+	breakerTarget = ""
+	defer func() { breakerTarget = orig }()
+
+	err := runBreakerReset(breakerResetCmd, nil)
+	require.NoError(t, err)
+}
+
+func TestBreakerReset_ClearsFailureCount(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("BOSUN_STATE_DIR", tmpDir)
+
+	orig := breakerTarget
+	breakerTarget = ""
+	defer func() { breakerTarget = orig }()
+
+	stateFile := filepath.Join(tmpDir, reconcile.DefaultStateFile)
+
+	// Seed state with failures.
+	state := &reconcile.DeployState{
+		AttemptCount:        3,
+		LastAttemptedCommit: "abc1234",
+		LastAlertedAttempt:  3,
+	}
+	require.NoError(t, reconcile.SaveState(stateFile, state))
+
+	err := runBreakerReset(breakerResetCmd, nil)
+	require.NoError(t, err)
+
+	// Verify state was cleared.
+	cleared := reconcile.LoadState(stateFile)
+	assert.Equal(t, 0, cleared.AttemptCount)
+	assert.Equal(t, "", cleared.LastAttemptedCommit)
+	assert.Equal(t, 0, cleared.LastAlertedAttempt)
+}
+
+func TestBreakerStatus_TargetStateFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("BOSUN_STATE_DIR", tmpDir)
+
+	orig := breakerTarget
+	breakerTarget = "staging"
+	defer func() { breakerTarget = orig }()
+
+	origDir := breakerStateDir
+	breakerStateDir = tmpDir
+	defer func() { breakerStateDir = origDir }()
+
+	// Seed failure state in the named target's state file.
+	targetStateFile := filepath.Join(tmpDir, "deploy-state-staging.json")
+	state := &reconcile.DeployState{
+		AttemptCount:        3,
+		LastAttemptedCommit: "deadbeef",
+	}
+	require.NoError(t, reconcile.SaveState(targetStateFile, state))
+
+	// Status should read from the target-specific file (no error = success).
+	err := runBreakerStatus(breakerStatusCmd, nil)
+	require.NoError(t, err)
+}

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -115,48 +114,12 @@ func secondsToDuration(seconds int) time.Duration {
 }
 
 // createDaemonAlertManager creates an alert manager for the daemon.
+// Always returns a non-nil manager (callers check HasProviders() to decide
+// whether to use it). Uses BOSUN_-first precedence for all alert env vars.
 func createDaemonAlertManager() *alert.Manager {
-	mgr := alert.NewManager()
-
-	// Add Discord provider
-	discord := alert.NewDiscordProvider(os.Getenv("DISCORD_WEBHOOK_URL"))
-	mgr.AddProvider(discord)
-
-	// Add Slack provider
-	slack := alert.NewSlackProvider(os.Getenv("SLACK_WEBHOOK_URL"))
-	mgr.AddProvider(slack)
-
-	// Add SendGrid provider
-	toEmails := filterEmptyStrings(strings.Split(os.Getenv("SENDGRID_TO_EMAILS"), ","))
-	sendgrid := alert.NewSendGrid(alert.SendGridConfig{
-		APIKey:    os.Getenv("SENDGRID_API_KEY"),
-		FromEmail: os.Getenv("SENDGRID_FROM_EMAIL"),
-		FromName:  os.Getenv("SENDGRID_FROM_NAME"),
-		ToEmails:  toEmails,
-	})
-	mgr.AddProvider(sendgrid)
-
-	// Add Twilio provider
-	toNumbers := filterEmptyStrings(strings.Split(os.Getenv("TWILIO_TO_NUMBERS"), ","))
-	twilio := alert.NewTwilio(alert.TwilioConfig{
-		AccountSID: os.Getenv("TWILIO_ACCOUNT_SID"),
-		AuthToken:  os.Getenv("TWILIO_AUTH_TOKEN"),
-		FromNumber: os.Getenv("TWILIO_FROM_NUMBER"),
-		ToNumbers:  toNumbers,
-	})
-	mgr.AddProvider(twilio)
-
-	// Add Webhook provider
-	webhook := alert.NewWebhookProvider(alert.WebhookConfig{
-		URL:     os.Getenv("BOSUN_WEBHOOK_URL"),
-		Headers: parseJSONHeaders(os.Getenv("BOSUN_WEBHOOK_HEADERS")),
-		Method:  os.Getenv("BOSUN_WEBHOOK_METHOD"),
-	})
-	mgr.AddProvider(webhook)
-
+	mgr := buildAlertManagerRaw() // defined in reconcile.go
 	if mgr.HasProviders() {
 		ui.Info("Alert providers: %v", mgr.ProviderNames())
 	}
-
 	return mgr
 }

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -2,12 +2,10 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/cameronsjo/bosun/internal/docker"
-	"github.com/cameronsjo/bosun/internal/log"
 )
 
 // DefaultOperationTimeout is the default timeout for Docker operations.
@@ -36,16 +34,3 @@ func withDockerClientContext(ctx context.Context, fn func(*docker.Client) error)
 	return fn(client)
 }
 
-// parseJSONHeaders parses a JSON string into a map of HTTP headers.
-// Returns nil if the input is empty. Logs a warning and returns nil on invalid JSON.
-func parseJSONHeaders(raw string) map[string]string {
-	if raw == "" {
-		return nil
-	}
-	var headers map[string]string
-	if err := json.Unmarshal([]byte(raw), &headers); err != nil {
-		log.Warn().Err(err).Msg("BOSUN_WEBHOOK_HEADERS contains invalid JSON; ignoring")
-		return nil
-	}
-	return headers
-}

--- a/internal/cmd/reconcile.go
+++ b/internal/cmd/reconcile.go
@@ -75,14 +75,14 @@ func runReconcile(cmd *cobra.Command, args []string) {
 	// Build configuration from environment and flags.
 	cfg := reconcile.DefaultConfig()
 
-	// Required: repo URL.
-	cfg.RepoURL = os.Getenv("REPO_URL")
+	// Required: repo URL. BOSUN_REPO_URL takes precedence over legacy REPO_URL.
+	cfg.RepoURL = config.BosunEnv("REPO_URL")
 	if cfg.RepoURL == "" {
-		ui.Fatal("REPO_URL environment variable is required")
+		ui.Fatal("BOSUN_REPO_URL (or legacy REPO_URL) environment variable is required")
 	}
 
 	// Optional settings from environment.
-	if branch := os.Getenv("REPO_BRANCH"); branch != "" {
+	if branch := config.BosunEnv("REPO_BRANCH"); branch != "" {
 		cfg.RepoBranch = branch
 	}
 	if repoDir := os.Getenv("REPO_DIR"); repoDir != "" {
@@ -313,50 +313,76 @@ func runReconcile(cmd *cobra.Command, args []string) {
 }
 
 // createAlertManager creates an alert manager with configured providers.
+// Returns nil when no providers are configured.
+// BOSUN_-prefixed env vars take precedence over legacy unprefixed vars;
+// project config (bosun.yaml) provides a further fallback via config.Load().
 func createAlertManager() *alert.Manager {
+	mgr := buildAlertManagerRaw()
+	if !mgr.HasProviders() {
+		return nil
+	}
+	ui.Info("Alert providers: %v", mgr.ProviderNames())
+	return mgr
+}
+
+// buildAlertManagerRaw assembles the alert.Manager from config + env.
+// Always returns a non-nil manager; callers check HasProviders() to decide
+// whether any providers were actually configured.
+func buildAlertManagerRaw() *alert.Manager {
 	mgr := alert.NewManager()
 
+	// Resolve credentials: config.Load() applies BOSUN_-first precedence for
+	// all alert env vars (BOSUN_DISCORD_WEBHOOK_URL > DISCORD_WEBHOOK_URL, etc.).
+	var alertCfg config.AlertConfig
+	if projectCfg, err := config.Load(); err == nil {
+		alertCfg = projectCfg.GetAlertConfig()
+	} else {
+		// No project config — fall back to raw env-var resolution.
+		alertCfg = config.AlertConfigFromEnv()
+	}
+
 	// Add Discord provider.
-	discord := alert.NewDiscordProvider(os.Getenv("DISCORD_WEBHOOK_URL"))
+	discord := alert.NewDiscordProvider(alertCfg.DiscordWebhookURL)
 	mgr.AddProvider(discord)
 
 	// Add Slack provider.
-	slack := alert.NewSlackProvider(os.Getenv("SLACK_WEBHOOK_URL"))
+	slack := alert.NewSlackProvider(alertCfg.SlackWebhookURL)
 	mgr.AddProvider(slack)
 
 	// Add SendGrid provider.
 	toEmails := filterEmptyStrings(strings.Split(os.Getenv("SENDGRID_TO_EMAILS"), ","))
+	if v := os.Getenv("BOSUN_SENDGRID_TO_EMAILS"); v != "" {
+		toEmails = filterEmptyStrings(strings.Split(v, ","))
+	}
 	sendgrid := alert.NewSendGrid(alert.SendGridConfig{
-		APIKey:    os.Getenv("SENDGRID_API_KEY"),
-		FromEmail: os.Getenv("SENDGRID_FROM_EMAIL"),
-		FromName:  os.Getenv("SENDGRID_FROM_NAME"),
+		APIKey:    alertCfg.SendGridAPIKey,
+		FromEmail: alertCfg.SendGridFromEmail,
+		FromName:  alertCfg.SendGridFromName,
 		ToEmails:  toEmails,
 	})
 	mgr.AddProvider(sendgrid)
 
 	// Add Twilio provider.
 	toNumbers := filterEmptyStrings(strings.Split(os.Getenv("TWILIO_TO_NUMBERS"), ","))
+	if v := os.Getenv("BOSUN_TWILIO_TO_NUMBERS"); v != "" {
+		toNumbers = filterEmptyStrings(strings.Split(v, ","))
+	}
 	twilio := alert.NewTwilio(alert.TwilioConfig{
-		AccountSID: os.Getenv("TWILIO_ACCOUNT_SID"),
-		AuthToken:  os.Getenv("TWILIO_AUTH_TOKEN"),
-		FromNumber: os.Getenv("TWILIO_FROM_NUMBER"),
+		AccountSID: alertCfg.TwilioAccountSID,
+		AuthToken:  alertCfg.TwilioAuthToken,
+		FromNumber: alertCfg.TwilioFromNumber,
 		ToNumbers:  toNumbers,
 	})
 	mgr.AddProvider(twilio)
 
 	// Add Webhook provider.
 	webhook := alert.NewWebhookProvider(alert.WebhookConfig{
-		URL:     os.Getenv("BOSUN_WEBHOOK_URL"),
-		Headers: parseJSONHeaders(os.Getenv("BOSUN_WEBHOOK_HEADERS")),
-		Method:  os.Getenv("BOSUN_WEBHOOK_METHOD"),
+		URL:     alertCfg.WebhookURL,
+		Headers: alertCfg.WebhookHeaders,
+		Method:  alertCfg.WebhookMethod,
 	})
 	mgr.AddProvider(webhook)
 
-	if !mgr.HasProviders() {
-		return nil
-	}
-
-	ui.Info("Alert providers: %v", mgr.ProviderNames())
 	return mgr
 }
 

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -109,23 +109,25 @@ func runValidate(cmd *cobra.Command, args []string) {
 func validateEnvironment() int {
 	errors := 0
 
-	// Check for required environment variables
-	repoURL := os.Getenv("REPO_URL")
+	// Check for required environment variables.
+	// BOSUN_REPO_URL takes precedence over legacy REPO_URL.
+	repoURL := os.Getenv("BOSUN_REPO_URL")
 	if repoURL == "" {
-		repoURL = os.Getenv("BOSUN_REPO_URL")
+		repoURL = os.Getenv("REPO_URL")
 	}
 
 	if repoURL != "" {
 		_, _ = ui.Green.Printf("  * REPO_URL: %s\n", repoURL)
 	} else {
-		_, _ = ui.Red.Println("  x REPO_URL or BOSUN_REPO_URL not set")
+		_, _ = ui.Red.Println("  x BOSUN_REPO_URL (or legacy REPO_URL) not set")
 		errors++
 	}
 
-	// Check optional but important variables
-	branch := os.Getenv("REPO_BRANCH")
+	// Check optional but important variables.
+	// BOSUN_REPO_BRANCH takes precedence over legacy REPO_BRANCH.
+	branch := os.Getenv("BOSUN_REPO_BRANCH")
 	if branch == "" {
-		branch = os.Getenv("BOSUN_REPO_BRANCH")
+		branch = os.Getenv("REPO_BRANCH")
 	}
 	if branch == "" {
 		branch = "main (default)"
@@ -209,10 +211,10 @@ func validateReconcileConfig() int {
 
 	cfg := reconcile.DefaultConfig()
 
-	// Load from environment
-	cfg.RepoURL = os.Getenv("REPO_URL")
+	// Load from environment. BOSUN_REPO_URL takes precedence over legacy REPO_URL.
+	cfg.RepoURL = os.Getenv("BOSUN_REPO_URL")
 	if cfg.RepoURL == "" {
-		cfg.RepoURL = os.Getenv("BOSUN_REPO_URL")
+		cfg.RepoURL = os.Getenv("REPO_URL")
 	}
 
 	if cfg.RepoURL == "" {
@@ -244,16 +246,16 @@ func validateReconcileConfig() int {
 func runFullDryRun() error {
 	cfg := reconcile.DefaultConfig()
 
-	// Load from environment
-	cfg.RepoURL = os.Getenv("REPO_URL")
+	// Load from environment. BOSUN_REPO_URL takes precedence over legacy REPO_URL.
+	cfg.RepoURL = os.Getenv("BOSUN_REPO_URL")
 	if cfg.RepoURL == "" {
-		cfg.RepoURL = os.Getenv("BOSUN_REPO_URL")
+		cfg.RepoURL = os.Getenv("REPO_URL")
 	}
 
-	if branch := os.Getenv("REPO_BRANCH"); branch != "" {
-		cfg.RepoBranch = branch
-	}
+	// BOSUN_REPO_BRANCH takes precedence over legacy REPO_BRANCH.
 	if branch := os.Getenv("BOSUN_REPO_BRANCH"); branch != "" {
+		cfg.RepoBranch = branch
+	} else if branch := os.Getenv("REPO_BRANCH"); branch != "" {
 		cfg.RepoBranch = branch
 	}
 

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -281,4 +281,45 @@ func TestValidateReconcileConfig(t *testing.T) {
 		errors := validateReconcileConfig()
 		assert.Equal(t, 0, errors)
 	})
+
+	t.Run("BOSUN_REPO_URL wins over REPO_URL when both set", func(t *testing.T) {
+		// REPO_URL has an invalid URL; BOSUN_REPO_URL has a valid one.
+		// If precedence is correct (BOSUN_ wins), validateReconcileConfig
+		// should return 0 errors.
+		t.Setenv("REPO_URL", "not-a-valid-url")
+		t.Setenv("BOSUN_REPO_URL", "https://github.com/user/repo")
+
+		errors := validateReconcileConfig()
+		assert.Equal(t, 0, errors, "BOSUN_REPO_URL should win over REPO_URL")
+	})
+}
+
+func TestValidateEnvironment_BOSUNPrecedence(t *testing.T) {
+	t.Run("BOSUN_REPO_URL wins over REPO_URL when both set", func(t *testing.T) {
+		// REPO_URL is empty; BOSUN_REPO_URL is set — should succeed.
+		t.Setenv("BOSUN_REPO_URL", "https://bosun.example.com/repo")
+		t.Setenv("REPO_URL", "")
+		t.Setenv("BOSUN_REPO_BRANCH", "")
+		t.Setenv("REPO_BRANCH", "")
+		t.Setenv("WEBHOOK_SECRET", "")
+		t.Setenv("GITHUB_WEBHOOK_SECRET", "")
+		t.Setenv("DEPLOY_TARGET", "")
+
+		errors := validateEnvironment()
+		assert.Equal(t, 0, errors)
+	})
+
+	t.Run("BOSUN_REPO_URL beats non-empty REPO_URL", func(t *testing.T) {
+		// Both set — BOSUN_ value should be shown (no error).
+		t.Setenv("BOSUN_REPO_URL", "https://bosun.example.com/repo")
+		t.Setenv("REPO_URL", "https://legacy.example.com/repo")
+		t.Setenv("BOSUN_REPO_BRANCH", "")
+		t.Setenv("REPO_BRANCH", "")
+		t.Setenv("WEBHOOK_SECRET", "")
+		t.Setenv("GITHUB_WEBHOOK_SECRET", "")
+		t.Setenv("DEPLOY_TARGET", "")
+
+		errors := validateEnvironment()
+		assert.Equal(t, 0, errors)
+	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -834,6 +834,26 @@ func getEnvOrDefault(envKey, defaultValue string) string {
 	return defaultValue
 }
 
+// AlertConfigFromEnv builds an AlertConfig purely from environment variables,
+// applying BOSUN_-first precedence without needing a project config file.
+// This is used as a fallback when config.Load() fails (no bosun.yaml present).
+func AlertConfigFromEnv() AlertConfig {
+	return AlertConfig{
+		DiscordWebhookURL: getEnvOrDefault("BOSUN_DISCORD_WEBHOOK_URL", getEnvOrDefault("DISCORD_WEBHOOK_URL", "")),
+		SlackWebhookURL:   getEnvOrDefault("BOSUN_SLACK_WEBHOOK_URL", getEnvOrDefault("SLACK_WEBHOOK_URL", "")),
+		SendGridAPIKey:    getEnvOrDefault("BOSUN_SENDGRID_API_KEY", getEnvOrDefault("SENDGRID_API_KEY", "")),
+		SendGridFromEmail: getEnvOrDefault("BOSUN_SENDGRID_FROM_EMAIL", getEnvOrDefault("SENDGRID_FROM_EMAIL", "")),
+		SendGridFromName:  getEnvOrDefault("BOSUN_SENDGRID_FROM_NAME", getEnvOrDefault("SENDGRID_FROM_NAME", "")),
+		TwilioAccountSID:  getEnvOrDefault("BOSUN_TWILIO_ACCOUNT_SID", getEnvOrDefault("TWILIO_ACCOUNT_SID", "")),
+		TwilioAuthToken:   getEnvOrDefault("BOSUN_TWILIO_AUTH_TOKEN", getEnvOrDefault("TWILIO_AUTH_TOKEN", "")),
+		TwilioFromNumber:  getEnvOrDefault("BOSUN_TWILIO_FROM_NUMBER", getEnvOrDefault("TWILIO_FROM_NUMBER", "")),
+		WebhookURL:        getEnvOrDefault("BOSUN_WEBHOOK_URL", ""),
+		WebhookMethod:     getEnvOrDefault("BOSUN_WEBHOOK_METHOD", ""),
+		// OnFailure defaults to true when neither flag is set (same as extractAlertConfig).
+		OnFailure: true,
+	}
+}
+
 // extractAlertConfig extracts alert configuration from a parsed config.
 // Supports environment variable overrides for sensitive values.
 func extractAlertConfig(cfg configFile) AlertConfig {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cameronsjo/bosun/internal/log"
@@ -834,6 +835,24 @@ func getEnvOrDefault(envKey, defaultValue string) string {
 	return defaultValue
 }
 
+// splitCommaSeparated splits a comma-separated env-var value into a trimmed,
+// non-empty string slice. Returns nil when the input is empty or blank.
+func splitCommaSeparated(v string) []string {
+	if v == "" {
+		return nil
+	}
+	var result []string
+	for _, s := range strings.Split(v, ",") {
+		if t := strings.TrimSpace(s); t != "" {
+			result = append(result, t)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
 // AlertConfigFromEnv builds an AlertConfig purely from environment variables,
 // applying BOSUN_-first precedence without needing a project config file.
 // This is used as a fallback when config.Load() fails (no bosun.yaml present).
@@ -844,11 +863,17 @@ func AlertConfigFromEnv() AlertConfig {
 		SendGridAPIKey:    getEnvOrDefault("BOSUN_SENDGRID_API_KEY", getEnvOrDefault("SENDGRID_API_KEY", "")),
 		SendGridFromEmail: getEnvOrDefault("BOSUN_SENDGRID_FROM_EMAIL", getEnvOrDefault("SENDGRID_FROM_EMAIL", "")),
 		SendGridFromName:  getEnvOrDefault("BOSUN_SENDGRID_FROM_NAME", getEnvOrDefault("SENDGRID_FROM_NAME", "")),
-		TwilioAccountSID:  getEnvOrDefault("BOSUN_TWILIO_ACCOUNT_SID", getEnvOrDefault("TWILIO_ACCOUNT_SID", "")),
-		TwilioAuthToken:   getEnvOrDefault("BOSUN_TWILIO_AUTH_TOKEN", getEnvOrDefault("TWILIO_AUTH_TOKEN", "")),
-		TwilioFromNumber:  getEnvOrDefault("BOSUN_TWILIO_FROM_NUMBER", getEnvOrDefault("TWILIO_FROM_NUMBER", "")),
-		WebhookURL:        getEnvOrDefault("BOSUN_WEBHOOK_URL", ""),
-		WebhookMethod:     getEnvOrDefault("BOSUN_WEBHOOK_METHOD", ""),
+		// BOSUN_SENDGRID_TO_EMAILS is a comma-separated list of recipient addresses.
+		// Without this, a provider initialized via env vars would have credentials but no
+		// recipients, causing IsConfigured() == false and silent alert drops.
+		SendGridToEmails: splitCommaSeparated(os.Getenv("BOSUN_SENDGRID_TO_EMAILS")),
+		TwilioAccountSID: getEnvOrDefault("BOSUN_TWILIO_ACCOUNT_SID", getEnvOrDefault("TWILIO_ACCOUNT_SID", "")),
+		TwilioAuthToken:  getEnvOrDefault("BOSUN_TWILIO_AUTH_TOKEN", getEnvOrDefault("TWILIO_AUTH_TOKEN", "")),
+		TwilioFromNumber: getEnvOrDefault("BOSUN_TWILIO_FROM_NUMBER", getEnvOrDefault("TWILIO_FROM_NUMBER", "")),
+		// BOSUN_TWILIO_TO_NUMBERS is a comma-separated list of recipient phone numbers.
+		TwilioToNumbers: splitCommaSeparated(os.Getenv("BOSUN_TWILIO_TO_NUMBERS")),
+		WebhookURL:      getEnvOrDefault("BOSUN_WEBHOOK_URL", ""),
+		WebhookMethod:   getEnvOrDefault("BOSUN_WEBHOOK_METHOD", ""),
 		// OnFailure defaults to true when neither flag is set (same as extractAlertConfig).
 		OnFailure: true,
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2029,3 +2029,150 @@ func TestExtractTargets_DeprecationWarning(t *testing.T) {
 	assert.Equal(t, "pi", targets[0].Name)
 	assert.Equal(t, "user@pi", targets[0].TargetHost)
 }
+
+func TestAlertConfigFromEnv_Empty(t *testing.T) {
+	// Clear all alert env vars so we get a clean baseline.
+	for _, k := range []string{
+		"BOSUN_DISCORD_WEBHOOK_URL", "DISCORD_WEBHOOK_URL",
+		"BOSUN_SENDGRID_API_KEY", "SENDGRID_API_KEY",
+		"BOSUN_SENDGRID_FROM_EMAIL", "SENDGRID_FROM_EMAIL",
+		"BOSUN_SENDGRID_FROM_NAME", "SENDGRID_FROM_NAME",
+		"BOSUN_SENDGRID_TO_EMAILS",
+		"BOSUN_TWILIO_ACCOUNT_SID", "TWILIO_ACCOUNT_SID",
+		"BOSUN_TWILIO_AUTH_TOKEN", "TWILIO_AUTH_TOKEN",
+		"BOSUN_TWILIO_FROM_NUMBER", "TWILIO_FROM_NUMBER",
+		"BOSUN_TWILIO_TO_NUMBERS",
+		"BOSUN_WEBHOOK_URL", "BOSUN_WEBHOOK_METHOD",
+		"BOSUN_SLACK_WEBHOOK_URL", "SLACK_WEBHOOK_URL",
+	} {
+		t.Setenv(k, "")
+	}
+
+	cfg := AlertConfigFromEnv()
+	assert.Equal(t, "", cfg.DiscordWebhookURL)
+	assert.Equal(t, "", cfg.SendGridAPIKey)
+	assert.Nil(t, cfg.SendGridToEmails)
+	assert.Nil(t, cfg.TwilioToNumbers)
+	// OnFailure defaults to true when neither flag is set.
+	assert.True(t, cfg.OnFailure)
+}
+
+func TestAlertConfigFromEnv_BOSUNPrefixWins(t *testing.T) {
+	t.Setenv("DISCORD_WEBHOOK_URL", "https://legacy.discord.example.com/hook")
+	t.Setenv("BOSUN_DISCORD_WEBHOOK_URL", "https://bosun.discord.example.com/hook")
+	t.Setenv("SENDGRID_API_KEY", "legacy-key")
+	t.Setenv("BOSUN_SENDGRID_API_KEY", "bosun-key")
+	t.Setenv("BOSUN_SENDGRID_FROM_EMAIL", "from@example.com")
+	t.Setenv("SENDGRID_FROM_EMAIL", "")
+	t.Setenv("BOSUN_SENDGRID_FROM_NAME", "Bosun")
+	t.Setenv("SENDGRID_FROM_NAME", "")
+	t.Setenv("BOSUN_SENDGRID_TO_EMAILS", "")
+	t.Setenv("BOSUN_TWILIO_ACCOUNT_SID", "")
+	t.Setenv("TWILIO_ACCOUNT_SID", "")
+	t.Setenv("BOSUN_TWILIO_AUTH_TOKEN", "")
+	t.Setenv("TWILIO_AUTH_TOKEN", "")
+	t.Setenv("BOSUN_TWILIO_FROM_NUMBER", "")
+	t.Setenv("TWILIO_FROM_NUMBER", "")
+	t.Setenv("BOSUN_TWILIO_TO_NUMBERS", "")
+	t.Setenv("BOSUN_WEBHOOK_URL", "")
+	t.Setenv("BOSUN_WEBHOOK_METHOD", "")
+	t.Setenv("BOSUN_SLACK_WEBHOOK_URL", "")
+	t.Setenv("SLACK_WEBHOOK_URL", "")
+
+	cfg := AlertConfigFromEnv()
+	assert.Equal(t, "https://bosun.discord.example.com/hook", cfg.DiscordWebhookURL)
+	assert.Equal(t, "bosun-key", cfg.SendGridAPIKey)
+	assert.Equal(t, "from@example.com", cfg.SendGridFromEmail)
+	assert.Equal(t, "Bosun", cfg.SendGridFromName)
+}
+
+func TestAlertConfigFromEnv_LegacyFallback(t *testing.T) {
+	// BOSUN_ vars absent, legacy vars present.
+	t.Setenv("BOSUN_DISCORD_WEBHOOK_URL", "")
+	t.Setenv("DISCORD_WEBHOOK_URL", "https://legacy.discord.example.com/hook")
+	t.Setenv("BOSUN_SENDGRID_API_KEY", "")
+	t.Setenv("SENDGRID_API_KEY", "legacy-key")
+	t.Setenv("BOSUN_SENDGRID_FROM_EMAIL", "")
+	t.Setenv("SENDGRID_FROM_EMAIL", "legacy@example.com")
+	t.Setenv("BOSUN_SENDGRID_FROM_NAME", "")
+	t.Setenv("SENDGRID_FROM_NAME", "Legacy")
+	t.Setenv("BOSUN_SENDGRID_TO_EMAILS", "")
+	t.Setenv("BOSUN_TWILIO_ACCOUNT_SID", "")
+	t.Setenv("TWILIO_ACCOUNT_SID", "AClegacy")
+	t.Setenv("BOSUN_TWILIO_AUTH_TOKEN", "")
+	t.Setenv("TWILIO_AUTH_TOKEN", "legacy-token")
+	t.Setenv("BOSUN_TWILIO_FROM_NUMBER", "")
+	t.Setenv("TWILIO_FROM_NUMBER", "+10000000000")
+	t.Setenv("BOSUN_TWILIO_TO_NUMBERS", "")
+	t.Setenv("BOSUN_WEBHOOK_URL", "")
+	t.Setenv("BOSUN_WEBHOOK_METHOD", "")
+	t.Setenv("BOSUN_SLACK_WEBHOOK_URL", "")
+	t.Setenv("SLACK_WEBHOOK_URL", "")
+
+	cfg := AlertConfigFromEnv()
+	assert.Equal(t, "https://legacy.discord.example.com/hook", cfg.DiscordWebhookURL)
+	assert.Equal(t, "legacy-key", cfg.SendGridAPIKey)
+	assert.Equal(t, "legacy@example.com", cfg.SendGridFromEmail)
+	assert.Equal(t, "Legacy", cfg.SendGridFromName)
+	assert.Equal(t, "AClegacy", cfg.TwilioAccountSID)
+	assert.Equal(t, "legacy-token", cfg.TwilioAuthToken)
+	assert.Equal(t, "+10000000000", cfg.TwilioFromNumber)
+}
+
+func TestAlertConfigFromEnv_SendGridToEmails(t *testing.T) {
+	for _, k := range []string{
+		"BOSUN_DISCORD_WEBHOOK_URL", "DISCORD_WEBHOOK_URL",
+		"BOSUN_SENDGRID_API_KEY", "SENDGRID_API_KEY",
+		"BOSUN_SENDGRID_FROM_EMAIL", "SENDGRID_FROM_EMAIL",
+		"BOSUN_SENDGRID_FROM_NAME", "SENDGRID_FROM_NAME",
+		"BOSUN_TWILIO_ACCOUNT_SID", "TWILIO_ACCOUNT_SID",
+		"BOSUN_TWILIO_AUTH_TOKEN", "TWILIO_AUTH_TOKEN",
+		"BOSUN_TWILIO_FROM_NUMBER", "TWILIO_FROM_NUMBER",
+		"BOSUN_TWILIO_TO_NUMBERS",
+		"BOSUN_WEBHOOK_URL", "BOSUN_WEBHOOK_METHOD",
+		"BOSUN_SLACK_WEBHOOK_URL", "SLACK_WEBHOOK_URL",
+	} {
+		t.Setenv(k, "")
+	}
+
+	t.Run("populated", func(t *testing.T) {
+		t.Setenv("BOSUN_SENDGRID_TO_EMAILS", "a@example.com, b@example.com , c@example.com")
+		cfg := AlertConfigFromEnv()
+		assert.Equal(t, []string{"a@example.com", "b@example.com", "c@example.com"}, cfg.SendGridToEmails)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Setenv("BOSUN_SENDGRID_TO_EMAILS", "")
+		cfg := AlertConfigFromEnv()
+		assert.Nil(t, cfg.SendGridToEmails)
+	})
+}
+
+func TestAlertConfigFromEnv_TwilioToNumbers(t *testing.T) {
+	for _, k := range []string{
+		"BOSUN_DISCORD_WEBHOOK_URL", "DISCORD_WEBHOOK_URL",
+		"BOSUN_SENDGRID_API_KEY", "SENDGRID_API_KEY",
+		"BOSUN_SENDGRID_FROM_EMAIL", "SENDGRID_FROM_EMAIL",
+		"BOSUN_SENDGRID_FROM_NAME", "SENDGRID_FROM_NAME",
+		"BOSUN_SENDGRID_TO_EMAILS",
+		"BOSUN_TWILIO_ACCOUNT_SID", "TWILIO_ACCOUNT_SID",
+		"BOSUN_TWILIO_AUTH_TOKEN", "TWILIO_AUTH_TOKEN",
+		"BOSUN_TWILIO_FROM_NUMBER", "TWILIO_FROM_NUMBER",
+		"BOSUN_WEBHOOK_URL", "BOSUN_WEBHOOK_METHOD",
+		"BOSUN_SLACK_WEBHOOK_URL", "SLACK_WEBHOOK_URL",
+	} {
+		t.Setenv(k, "")
+	}
+
+	t.Run("populated", func(t *testing.T) {
+		t.Setenv("BOSUN_TWILIO_TO_NUMBERS", "+11111111111, +22222222222")
+		cfg := AlertConfigFromEnv()
+		assert.Equal(t, []string{"+11111111111", "+22222222222"}, cfg.TwilioToNumbers)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Setenv("BOSUN_TWILIO_TO_NUMBERS", "")
+		cfg := AlertConfigFromEnv()
+		assert.Nil(t, cfg.TwilioToNumbers)
+	})
+}

--- a/internal/config/envutil.go
+++ b/internal/config/envutil.go
@@ -11,10 +11,23 @@ import (
 // the unprefixed legacy <name> if the BOSUN_ form is unset or empty.
 // Returns an empty string if neither is set.
 func BosunEnv(name string) string {
-	if v := getEnvOrDefault("BOSUN_"+name, ""); v != "" {
-		return v
+	v, _ := bosunEnvWithSource(name)
+	return v
+}
+
+// bosunEnvWithSource returns the resolved value and the name of the env var
+// that actually provided it ("BOSUN_<name>" or "<name>"), so callers can log
+// the correct source rather than always attributing the value to BOSUN_<name>.
+// Returns ("", "") when neither var is set.
+func bosunEnvWithSource(name string) (value, source string) {
+	bosunKey := "BOSUN_" + name
+	if v := getEnvOrDefault(bosunKey, ""); v != "" {
+		return v, bosunKey
 	}
-	return getEnvOrDefault(name, "")
+	if v := getEnvOrDefault(name, ""); v != "" {
+		return v, name
+	}
+	return "", ""
 }
 
 // BosunEnvBool parses BosunEnv(name) as a boolean with consistent semantics:
@@ -23,7 +36,7 @@ func BosunEnv(name string) string {
 //	"0", "false", "no", "off", ""     -> false (case-insensitive)
 //	anything else                     -> defaultVal, with a debug-level warning
 func BosunEnvBool(name string, defaultVal bool) bool {
-	v := BosunEnv(name)
+	v, src := bosunEnvWithSource(name)
 	if v == "" {
 		return defaultVal
 	}
@@ -34,7 +47,7 @@ func BosunEnvBool(name string, defaultVal bool) bool {
 		return false
 	default:
 		log.Debug().
-			Str("env", "BOSUN_"+name).
+			Str("env", src).
 			Str("value", v).
 			Bool("default", defaultVal).
 			Msg("Unrecognized boolean value; using default")
@@ -43,22 +56,26 @@ func BosunEnvBool(name string, defaultVal bool) bool {
 }
 
 // BosunEnvDuration parses BosunEnv(name) as a time.Duration.
-// Accepts bare integers (treated as seconds) for backward compatibility.
+// Accepts bare integers (treated as seconds) for backward compatibility with
+// legacy POLL_INTERVAL config that used raw seconds — equivalent to appending
+// "s" before parsing (e.g. "3600" -> "3600s" -> 1h0m0s).
 // Returns defaultVal on parse error or when the var is unset.
 func BosunEnvDuration(name string, defaultVal time.Duration) time.Duration {
-	v := BosunEnv(name)
+	v, src := bosunEnvWithSource(name)
 	if v == "" {
 		return defaultVal
 	}
 	if d, err := time.ParseDuration(v); err == nil {
 		return d
 	}
-	// Bare integer treated as seconds.
+	// Bare-integer fallback: "3600" is interpreted as seconds for backward
+	// compat with legacy POLL_INTERVAL config that used raw seconds.
+	// This is the same convention as time.ParseDuration("3600s").
 	if d, err := time.ParseDuration(v + "s"); err == nil {
 		return d
 	}
 	log.Debug().
-		Str("env", "BOSUN_"+name).
+		Str("env", src).
 		Str("value", v).
 		Msg("Unrecognized duration value; using default")
 	return defaultVal

--- a/internal/config/envutil.go
+++ b/internal/config/envutil.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"strings"
+	"time"
+
+	"github.com/cameronsjo/bosun/internal/log"
+)
+
+// BosunEnv returns the value of the BOSUN_<name> env var, falling back to
+// the unprefixed legacy <name> if the BOSUN_ form is unset or empty.
+// Returns an empty string if neither is set.
+func BosunEnv(name string) string {
+	if v := getEnvOrDefault("BOSUN_"+name, ""); v != "" {
+		return v
+	}
+	return getEnvOrDefault(name, "")
+}
+
+// BosunEnvBool parses BosunEnv(name) as a boolean with consistent semantics:
+//
+//	"1", "true", "yes", "on"          -> true  (case-insensitive)
+//	"0", "false", "no", "off", ""     -> false (case-insensitive)
+//	anything else                     -> defaultVal, with a debug-level warning
+func BosunEnvBool(name string, defaultVal bool) bool {
+	v := BosunEnv(name)
+	if v == "" {
+		return defaultVal
+	}
+	switch strings.ToLower(v) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		log.Debug().
+			Str("env", "BOSUN_"+name).
+			Str("value", v).
+			Bool("default", defaultVal).
+			Msg("Unrecognized boolean value; using default")
+		return defaultVal
+	}
+}
+
+// BosunEnvDuration parses BosunEnv(name) as a time.Duration.
+// Accepts bare integers (treated as seconds) for backward compatibility.
+// Returns defaultVal on parse error or when the var is unset.
+func BosunEnvDuration(name string, defaultVal time.Duration) time.Duration {
+	v := BosunEnv(name)
+	if v == "" {
+		return defaultVal
+	}
+	if d, err := time.ParseDuration(v); err == nil {
+		return d
+	}
+	// Bare integer treated as seconds.
+	if d, err := time.ParseDuration(v + "s"); err == nil {
+		return d
+	}
+	log.Debug().
+		Str("env", "BOSUN_"+name).
+		Str("value", v).
+		Msg("Unrecognized duration value; using default")
+	return defaultVal
+}

--- a/internal/config/envutil_test.go
+++ b/internal/config/envutil_test.go
@@ -1,0 +1,192 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBosunEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		bosunVar string // BOSUN_<name> value ("" = unset)
+		legacyVar string // <name> value ("" = unset)
+		want     string
+	}{
+		{
+			name:      "BOSUN_ only set",
+			bosunVar:  "https://bosun.example.com/repo",
+			legacyVar: "",
+			want:      "https://bosun.example.com/repo",
+		},
+		{
+			name:      "legacy only set",
+			bosunVar:  "",
+			legacyVar: "https://legacy.example.com/repo",
+			want:      "https://legacy.example.com/repo",
+		},
+		{
+			name:      "both set — BOSUN_ wins",
+			bosunVar:  "https://bosun.example.com/repo",
+			legacyVar: "https://legacy.example.com/repo",
+			want:      "https://bosun.example.com/repo",
+		},
+		{
+			name:      "neither set — returns empty",
+			bosunVar:  "",
+			legacyVar: "",
+			want:      "",
+		},
+		{
+			name:      "empty BOSUN_ falls through to legacy",
+			bosunVar:  "",
+			legacyVar: "https://legacy.example.com/repo",
+			want:      "https://legacy.example.com/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.bosunVar != "" {
+				t.Setenv("BOSUN_REPO_URL", tt.bosunVar)
+			} else {
+				t.Setenv("BOSUN_REPO_URL", "")
+			}
+			if tt.legacyVar != "" {
+				t.Setenv("REPO_URL", tt.legacyVar)
+			} else {
+				t.Setenv("REPO_URL", "")
+			}
+			got := BosunEnv("REPO_URL")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBosunEnvBool(t *testing.T) {
+	tests := []struct {
+		name       string
+		bosunVar   string
+		legacyVar  string
+		defaultVal bool
+		want       bool
+	}{
+		// True values
+		{"true string", "true", "", false, true},
+		{"1 string", "1", "", false, true},
+		{"yes string", "yes", "", false, true},
+		{"on string", "on", "", false, true},
+		{"TRUE uppercase", "TRUE", "", false, true},
+		{"Yes mixed case", "Yes", "", false, true},
+
+		// False values
+		{"false string", "false", "", true, false},
+		{"0 string", "0", "", true, false},
+		{"no string", "no", "", true, false},
+		{"off string", "off", "", true, false},
+		{"FALSE uppercase", "FALSE", "", true, false},
+		{"No mixed case", "No", "", true, false},
+
+		// Neither set — returns default
+		{"unset returns default true", "", "", true, true},
+		{"unset returns default false", "", "", false, false},
+
+		// BOSUN_ wins over legacy
+		{
+			name:       "BOSUN_ true wins over legacy false",
+			bosunVar:   "true",
+			legacyVar:  "false",
+			defaultVal: false,
+			want:       true,
+		},
+		{
+			name:       "BOSUN_ false wins over legacy true",
+			bosunVar:   "false",
+			legacyVar:  "true",
+			defaultVal: true,
+			want:       false,
+		},
+
+		// Legacy only
+		{
+			name:       "legacy no disables",
+			bosunVar:   "",
+			legacyVar:  "no",
+			defaultVal: true,
+			want:       false,
+		},
+		{
+			name:       "legacy yes enables",
+			bosunVar:   "",
+			legacyVar:  "yes",
+			defaultVal: false,
+			want:       true,
+		},
+
+		// Unrecognized value falls back to default
+		{"unrecognized uses default true", "maybe", "", true, true},
+		{"unrecognized uses default false", "maybe", "", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BOSUN_REMOVE_ORPHANS", tt.bosunVar)
+			t.Setenv("REMOVE_ORPHANS", tt.legacyVar)
+			got := BosunEnvBool("REMOVE_ORPHANS", tt.defaultVal)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBosunEnvDuration(t *testing.T) {
+	tests := []struct {
+		name       string
+		bosunVar   string
+		legacyVar  string
+		defaultVal time.Duration
+		want       time.Duration
+	}{
+		// Go duration strings
+		{"30s duration", "30s", "", 0, 30 * time.Second},
+		{"5m duration", "5m", "", 0, 5 * time.Minute},
+		{"1h30m duration", "1h30m", "", 0, 90 * time.Minute},
+
+		// Bare integer (seconds)
+		{"bare integer 30", "30", "", 0, 30 * time.Second},
+		{"bare integer 3600", "3600", "", 0, 3600 * time.Second},
+
+		// Neither set — returns default
+		{"unset returns default", "", "", 5 * time.Minute, 5 * time.Minute},
+
+		// BOSUN_ wins over legacy
+		{
+			name:       "BOSUN_ 10m wins over legacy 5m",
+			bosunVar:   "10m",
+			legacyVar:  "5m",
+			defaultVal: 0,
+			want:       10 * time.Minute,
+		},
+
+		// Legacy only
+		{
+			name:       "legacy 60s used when BOSUN_ unset",
+			bosunVar:   "",
+			legacyVar:  "60s",
+			defaultVal: 0,
+			want:       60 * time.Second,
+		},
+
+		// Invalid value — returns default
+		{"invalid returns default", "not-a-duration", "", 3 * time.Second, 3 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BOSUN_POLL_INTERVAL", tt.bosunVar)
+			t.Setenv("POLL_INTERVAL", tt.legacyVar)
+			got := BosunEnvDuration("POLL_INTERVAL", tt.defaultVal)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/config/envutil_test.go
+++ b/internal/config/envutil_test.go
@@ -7,6 +7,55 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBosunEnvWithSource(t *testing.T) {
+	tests := []struct {
+		name       string
+		bosunVal   string
+		legacyVal  string
+		wantValue  string
+		wantSource string
+	}{
+		{
+			name:       "BOSUN_ only set — source is BOSUN_ key",
+			bosunVal:   "bosun-value",
+			legacyVal:  "",
+			wantValue:  "bosun-value",
+			wantSource: "BOSUN_TEST_VAR",
+		},
+		{
+			name:       "legacy only set — source is bare key",
+			bosunVal:   "",
+			legacyVal:  "legacy-value",
+			wantValue:  "legacy-value",
+			wantSource: "TEST_VAR",
+		},
+		{
+			name:       "both set — BOSUN_ wins, source is BOSUN_ key",
+			bosunVal:   "bosun-wins",
+			legacyVal:  "legacy-value",
+			wantValue:  "bosun-wins",
+			wantSource: "BOSUN_TEST_VAR",
+		},
+		{
+			name:       "neither set — empty value and source",
+			bosunVal:   "",
+			legacyVal:  "",
+			wantValue:  "",
+			wantSource: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BOSUN_TEST_VAR", tt.bosunVal)
+			t.Setenv("TEST_VAR", tt.legacyVal)
+			gotVal, gotSrc := bosunEnvWithSource("TEST_VAR")
+			assert.Equal(t, tt.wantValue, gotVal)
+			assert.Equal(t, tt.wantSource, gotSrc)
+		})
+	}
+}
+
 func TestBosunEnv(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1334,13 +1334,13 @@ func ConfigFromEnv() *Config {
 	}
 
 	// Disable HTTP server if explicitly set
-	if os.Getenv("BOSUN_DISABLE_HTTP") == "true" {
-		cfg.EnableHTTP = false
+	if v := os.Getenv("BOSUN_DISABLE_HTTP"); v != "" {
+		cfg.EnableHTTP = !parseBoolVal(v, false)
 	}
 
 	// TCP server configuration (opt-in)
-	if os.Getenv("BOSUN_ENABLE_TCP") == "true" {
-		cfg.EnableTCP = true
+	if v := os.Getenv("BOSUN_ENABLE_TCP"); v != "" {
+		cfg.EnableTCP = parseBoolVal(v, false)
 	}
 	if addr := os.Getenv("BOSUN_TCP_ADDR"); addr != "" {
 		cfg.TCPAddr = addr
@@ -1392,7 +1392,7 @@ func ConfigFromEnv() *Config {
 		rcfg.SecretsFiles = splitAndTrim(secrets)
 	}
 
-	rcfg.DryRun = os.Getenv("DRY_RUN") == "true"
+	rcfg.DryRun = parseBoolVal(os.Getenv("DRY_RUN"), false)
 
 	// Deploy mode override: "local" or "remote" skips auto-detection.
 	if mode := os.Getenv("BOSUN_DEPLOY_MODE"); mode != "" {
@@ -1461,7 +1461,7 @@ func ConfigFromEnv() *Config {
 
 	// Restart circuit breaker configuration
 	if v := os.Getenv("BOSUN_RESTART_BREAKER"); v != "" {
-		rcfg.RestartBreakerEnabled = v != "false" && v != "0"
+		rcfg.RestartBreakerEnabled = parseBoolVal(v, true)
 	}
 	if v := os.Getenv("BOSUN_RESTART_THRESHOLD"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
@@ -1540,12 +1540,12 @@ func ConfigFromEnv() *Config {
 		}
 	}
 	if v := os.Getenv("BOSUN_DRIFT_RESOLVE_ALERTS"); v != "" {
-		cfg.DriftResolveAlerts = v != "false" && v != "0"
+		cfg.DriftResolveAlerts = parseBoolVal(v, true)
 	}
 
 	// Drift self-healing (default: false)
 	if v := os.Getenv("BOSUN_DRIFT_SELF_HEAL"); v != "" {
-		cfg.DriftSelfHeal.SetFromEnv(v == "true" || v == "1")
+		cfg.DriftSelfHeal.SetFromEnv(parseBoolVal(v, false))
 	}
 	if v := os.Getenv("BOSUN_DRIFT_SELF_HEAL_COOLDOWN"); v != "" {
 		if d, ok := parseDurationOrSeconds(v); ok {
@@ -1561,18 +1561,21 @@ func ConfigFromEnv() *Config {
 
 	// Content-hash file sync (default: true)
 	if v := os.Getenv("BOSUN_CONTENT_HASH_SYNC"); v != "" {
-		cfg.ContentHashSync = v != "false" && v != "0"
+		cfg.ContentHashSync = parseBoolVal(v, true)
 	}
 	rcfg.ContentHashSync = cfg.ContentHashSync
 
 	// Orphan container cleanup (default: true)
 	if v := os.Getenv("BOSUN_REMOVE_ORPHANS"); v != "" {
-		cfg.RemoveOrphans = v != "false" && v != "0"
+		cfg.RemoveOrphans = parseBoolVal(v, true)
 		rcfg.RemoveOrphans.SetFromEnv(cfg.RemoveOrphans)
 	} else {
 		rcfg.RemoveOrphans = reconcile.NewConfigField(cfg.RemoveOrphans)
 	}
 
+	// Safety overrides use strict lowercase "true" match — intentional.
+	// These gates guard against accidental activation of dangerous behavior;
+	// "yes", "1", "TRUE" etc. are rejected by design.
 	rcfg.AllowEmptyDeclaredState = os.Getenv("BOSUN_ALLOW_EMPTY_DECLARED_STATE") == "true"
 	rcfg.SkipDeployInvariant = os.Getenv("BOSUN_SKIP_DEPLOY_INVARIANT") == "true"
 
@@ -1700,6 +1703,26 @@ func ConfigFromEnv() *Config {
 	}
 
 	return cfg
+}
+
+// parseBoolVal parses a string as a boolean with consistent semantics:
+//
+//	"1", "true", "yes", "on"      -> true  (case-insensitive)
+//	"0", "false", "no", "off"     -> false (case-insensitive)
+//	anything else                 -> defaultVal
+//
+// This is the canonical boolean parser for all BOSUN_ env vars in the daemon.
+// Using a single helper prevents the scattered patterns ("== true", "!= false && != 0")
+// from diverging and ensures "no"/"yes" work everywhere (GH #263).
+func parseBoolVal(v string, defaultVal bool) bool {
+	switch strings.ToLower(v) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return defaultVal
+	}
 }
 
 // splitAndTrim splits a comma-separated string and trims whitespace.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1352,32 +1352,14 @@ func ConfigFromEnv() *Config {
 		cfg.WebhookSecret = secret
 	}
 
-	if interval := os.Getenv("POLL_INTERVAL"); interval != "" {
-		if d, ok := parseDurationOrSeconds(interval); ok {
-			cfg.PollInterval = d
-		} else {
-			log.Warn().Str("env", "POLL_INTERVAL").Str("value", interval).Msg("Skipping env var. Reason: invalid duration format")
-		}
-	}
-	if interval := os.Getenv("BOSUN_POLL_INTERVAL"); interval != "" {
-		if d, ok := parseDurationOrSeconds(interval); ok {
-			cfg.PollInterval = d
-		} else {
-			log.Warn().Str("env", "BOSUN_POLL_INTERVAL").Str("value", interval).Msg("Skipping env var. Reason: invalid duration format")
-		}
+	if d := config.BosunEnvDuration("POLL_INTERVAL", 0); d > 0 {
+		cfg.PollInterval = d
 	}
 
 	// Reconcile config from environment
 	rcfg := reconcile.DefaultConfig()
-	rcfg.RepoURL = os.Getenv("REPO_URL")
-	if url := os.Getenv("BOSUN_REPO_URL"); url != "" {
-		rcfg.RepoURL = url
-	}
-
-	if branch := os.Getenv("REPO_BRANCH"); branch != "" {
-		rcfg.RepoBranch = branch
-	}
-	if branch := os.Getenv("BOSUN_REPO_BRANCH"); branch != "" {
+	rcfg.RepoURL = config.BosunEnv("REPO_URL")
+	if branch := config.BosunEnv("REPO_BRANCH"); branch != "" {
 		rcfg.RepoBranch = branch
 	}
 


### PR DESCRIPTION
## Summary

- **GH #237** — `bosun breaker status/reset` had no `--target` flag, breaking multi-target deployments. Added `--target` (`-t`) matching the drift command UX, resolving the correct per-target state file via `reconcile.TargetStateFile`.
- **GH #238** — `bosun reconcile` read only legacy `REPO_URL`, ignoring `BOSUN_REPO_URL`. Fixed to prefer `BOSUN_REPO_URL`.
- **GH #239** — `createDaemonAlertManager` and `createAlertManager` in `cmd/daemon.go` and `cmd/reconcile.go` read only legacy unprefixed alert vars (`DISCORD_WEBHOOK_URL` etc.), bypassing documented `BOSUN_DISCORD_WEBHOOK_URL` > legacy precedence. Both now route through `config.AlertConfig` (via `config.Load()` / `config.AlertConfigFromEnv()`) which already has correct BOSUN_-first resolution.
- **GH #263** — Boolean env-var parsing was inconsistent across daemon: `== "true"` (rejects yes/1/on), `!= "false" && != "0"` (rejects no/off), `== "true" || == "1"` (rejects yes/on). Added `parseBoolVal()` and applied it to all operational booleans. Safety-gate vars (`BOSUN_ALLOW_EMPTY_DECLARED_STATE`, `BOSUN_SKIP_DEPLOY_INVARIANT`) intentionally keep strict `== "true"` — guarded by an explicit test.
- **GH #289** — `cmd/validate.go` read `REPO_URL` first then `BOSUN_REPO_URL` in three functions (opposite of daemon). Flipped all three to BOSUN_-first.

Additionally adds:
- `internal/config/envutil.go` — `BosunEnv`, `BosunEnvBool`, `BosunEnvDuration` helpers for future use
- `config.AlertConfigFromEnv()` — resolves alert credentials from env alone (no project config required)

Closes #237, #238, #239, #263, #289

## Test plan

- [ ] `make build` succeeds
- [ ] `go test ./internal/cmd/... ./internal/config/...` passes (all new tests green)
- [ ] `go test ./internal/config/... -run TestBosunEnv` — full BosunEnv matrix
- [ ] `go test ./internal/cmd/... -run TestBreaker` — breaker --target flag tests
- [ ] `go test ./internal/cmd/... -run TestValidate` — BOSUN_ precedence tests
- [ ] Smoke: `BOSUN_REPO_URL=new REPO_URL=old bosun validate` reports `new` (not `old`)
- [ ] `go test ./internal/daemon/... -run TestConfigFromEnv` passes (safety-gate strict match still enforced)
- [ ] Pre-existing daemon flakes (`TestSocketHandleTrigger`, `TestTCPHandleTrigger`) confirmed present on `main` — not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)