### PR TITLE
spec: add-daemon-security — fail-closed daemon HTTP/socket posture (Cluster B)

### DIFF
--- a/openspec/changes/add-daemon-security/design.md
+++ b/openspec/changes/add-daemon-security/design.md
@@ -1,0 +1,79 @@
+## Context
+
+The daemon exposes three network/IPC surfaces (HTTP webhook server, Unix socket,
+optional TCP API) plus an HTTP API handler. Each evolved independently, so their
+security postures diverge: the TCP server has bearer-token `authMiddleware` and
+`auditMiddleware`; the socket extracts peer credentials but discards them; the
+webhook server gates signature checks on a non-empty secret and otherwise
+fails open. The default config enables HTTP and binds `:8080` on all interfaces.
+
+This change unifies the posture around **fail-closed by default** without
+breaking the single-binary, zero-dependency homelab deployment model. Stakeholders
+are homelab operators who frequently run with minimal config; the design must make
+the safe path the default while leaving a clearly-labeled escape hatch.
+
+## Goals / Non-Goals
+
+- Goals:
+  - No unauthenticated mutating trigger reachable by default on any surface.
+  - Reuse existing primitives (`authMiddleware`, `auditMiddleware`,
+    `InjectPeerCred`) rather than introduce a new auth framework.
+  - Backwards-compatibility via explicit, loud opt-in flags — never silent.
+- Non-Goals:
+  - TLS termination / mTLS for the HTTP servers (out of scope; reverse-proxy
+    territory).
+  - Per-route RBAC beyond owner/allowlist UID and bearer token.
+  - Rate limiting beyond header/body bounds (separate concern, Cluster I).
+
+## Decisions
+
+- **Decision: Startup gate over per-request rejection for the empty-secret case.**
+  Failing at startup (rather than 401-ing every webhook) surfaces the
+  misconfiguration immediately and prevents a daemon that silently accepts
+  nothing useful. The `BOSUN_ALLOW_UNSIGNED_WEBHOOKS` escape hatch preserves the
+  current behavior for operators who knowingly run on a trusted LAN segment.
+  - Alternatives considered: default-deny at request time (less discoverable);
+    auto-generate a secret (breaks the GitHub-side shared-secret model).
+
+- **Decision: Peer UID allowlist with fail-closed default.**
+  `SO_PEERCRED` is already wired on Linux; the gap is enforcement. Owner-UID is
+  always allowed; `BOSUN_SOCKET_ALLOWED_UIDS` extends it. On platforms without
+  peer creds the mutating handlers deny by default — the socket is then only
+  safe behind file-mode, so denying mutation is the conservative choice.
+  - Alternatives considered: group-based allowlist (coarser; the 0660 group is
+    exactly the over-broad grant we're closing).
+
+- **Decision: Reuse `MaxBytesReader` + small trigger limit (e.g. 64KB).**
+  The trigger schema is `{source, force}`; 64KB is generous. The webhook body
+  limit (1MB) stays for signed payloads which legitimately carry full push JSON.
+
+- **Decision: Metrics/widget default to localhost-or-opt-in.**
+  Homepage-dashboard users who relied on remote `/api/widget` set the opt-in;
+  this is the documented breaking change with a one-line migration.
+
+## Risks / Trade-offs
+
+- **Breaking change for secret-less HTTP deployments** → mitigated by the opt-in
+  flag and a clear startup error message naming the exact env var to set.
+- **Peer-cred enforcement could lock out legitimate tooling running as a
+  different UID** → mitigated by the allowlist and by allowing the daemon owner
+  unconditionally.
+- **Metrics gating could break existing dashboards** → mitigated by documenting
+  the opt-in and keeping localhost access unchanged.
+
+## Migration Plan
+
+1. Operators running HTTP without a secret: set `WEBHOOK_SECRET`, or set
+   `BOSUN_ALLOW_UNSIGNED_WEBHOOKS=true` to retain current behavior.
+2. Operators consuming `/api/widget` or `/metrics` remotely: set the
+   metrics-exposure opt-in.
+3. Rollback: unset the new env vars; the startup gate is the only hard behavior
+   change and is itself gated by the opt-in.
+
+## Open Questions
+
+- Should `BOSUN_SOCKET_ALLOWED_UIDS` accept usernames in addition to numeric
+  UIDs? (Lean: numeric only for v1, document the mapping.)
+- Exact name for the metrics-exposure opt-in (`BOSUN_METRICS_EXPOSE` vs
+  `BOSUN_EXPOSE_METRICS`) — settle during implementation for env-var-table
+  consistency.

--- a/openspec/changes/add-daemon-security/proposal.md
+++ b/openspec/changes/add-daemon-security/proposal.md
@@ -1,0 +1,79 @@
+# Change: Daemon HTTP and Unix-socket security hardening
+
+## Why
+
+The April 2026 reconcile-path bug hunt found that the daemon's network and IPC
+surfaces are unauthenticated or fail-open in their default configuration. The
+HTTP webhook server defaults to enabled and binds `:8080` on all interfaces; when
+no webhook secret is configured it accepts **any** unsigned POST as a valid
+GitOps trigger (GHSA-q67h-gp7c-rx88, Critical). The Unix socket extracts peer
+credentials but never enforces them, so any local UID in the daemon's group can
+force a reconcile (#253). The socket hard-codes `0660` and races between
+`net.Listen` and `Chmod` (#254). No HTTP server sets `ReadHeaderTimeout` or
+`MaxHeaderBytes`, exposing a pre-auth Slowloris vector (#255). The trigger JSON
+handlers decode bodies without a size cap (#295). `/metrics` and `/api/widget`
+disclose the deployed commit and reconcile cadence to anonymous callers (#296).
+GitHub pusher names from unsigned payloads flow unbounded into logs, OTEL spans,
+and Sentry (#297).
+
+There is no spec describing the daemon's security posture, so these are
+implementation gaps with no authoritative requirement to regress against. This
+proposal establishes a `daemon-security` capability that makes the daemon
+**fail-closed by default** across every entry point.
+
+## What Changes
+
+- **Webhook fail-closed startup gate** — when HTTP is enabled and no webhook
+  secret is set, the daemon SHALL refuse to start unless the operator explicitly
+  opts in via `BOSUN_ALLOW_UNSIGNED_WEBHOOKS=true`, which logs a loud security
+  warning on startup and on every webhook receipt. **BREAKING**: existing
+  secret-less HTTP deployments must set a secret or opt in.
+- **Unix socket peer-credential enforcement** — the socket SHALL reject trigger
+  requests whose peer UID is not the daemon owner or in a configured allowlist,
+  and SHALL fail-closed when peer credentials are unavailable (including
+  non-Linux platforms unless explicitly overridden).
+- **Socket permission integrity** — the socket SHALL be created with its
+  configured mode with no world-connectable window (honor `SocketMode`, set umask
+  before listen).
+- **HTTP request hardening** — every daemon HTTP server (webhook, socket, TCP)
+  SHALL set `ReadHeaderTimeout` and `MaxHeaderBytes`, and SHALL bound trigger
+  request bodies with `http.MaxBytesReader`.
+- **Anonymous-endpoint exposure control** — `/metrics` and `/api/widget` SHALL
+  NOT be reachable by unauthenticated remote callers in the default
+  configuration (localhost-bound, auth-gated, or explicitly flag-enabled).
+- **Webhook payload sanitization** — attacker-controlled fields (pusher name)
+  SHALL be length-capped and control-character-sanitized before being logged,
+  recorded in spans, or sent to telemetry sinks.
+
+## Impact
+
+- Affected specs: NEW capability `daemon-security`. Touches behavior also
+  described in `reconcile` (trigger entry points) and `observability` (metrics
+  exposure), but adds no requirements there.
+- Affected code:
+  - `internal/daemon/server.go` — webhook handlers (`:191`, `:259`, `:360`),
+    `handleWidget` (`:457`), `/metrics` registration (`:68`), `http.Server`
+    config (`:70`), pusher-name logging (`:327`, `:342`)
+  - `internal/daemon/socket.go` — `net.Listen`/`Chmod` (`:82`), `handleTrigger`
+    body decode (`:156`), `http.Server` config (`:60`)
+  - `internal/daemon/tcp.go` — `http.Server` config (`:45`), `handleTrigger`
+    (`:154`), existing `authMiddleware`/`auditMiddleware`
+  - `internal/daemon/api.go` — `handleAPITrigger` (`:289`)
+  - `internal/daemon/peercred_linux.go` / `peercred_other.go` —
+    `getPeerCredentials`, `WrapServerForPeerCred`, `InjectPeerCred`
+  - `internal/daemon/daemon.go` — `Config` (`SocketMode` `:189`, `EnableHTTP`
+    `:89`, `WebhookSecret` `:1350`), `ValidateConfig` (`:1733`), `ConfigFromEnv`
+- All consumers of the trigger surface (each needs its own scenario + task):
+  - HTTP webhook server (`server.go`) — `/webhook`, `/webhook/github`,
+    `/webhook/manual`
+  - Unix socket server (`socket.go`) — `POST /trigger`
+  - TCP API server (`tcp.go`) — `POST /trigger`, bearer-token gated
+  - HTTP API (`api.go`) — `handleAPITrigger`
+- New config / env vars:
+  - `BOSUN_ALLOW_UNSIGNED_WEBHOOKS` (bool, default false)
+  - `BOSUN_SOCKET_ALLOWED_UIDS` / allowlist config (existing `SocketMode` becomes
+    load-bearing)
+  - `BOSUN_METRICS_EXPOSE` (or equivalent) to opt metrics/widget into remote
+    exposure
+- Docs: `docs/security.md`, `skills/onboard/resources/gitops.md` (daemon
+  security posture), `CLAUDE.md` env-var table.

--- a/openspec/changes/add-daemon-security/specs/daemon-security/spec.md
+++ b/openspec/changes/add-daemon-security/specs/daemon-security/spec.md
@@ -1,0 +1,130 @@
+## ADDED Requirements
+
+### Requirement: Webhook authentication fail-closed
+
+The daemon SHALL NOT accept unsigned webhook requests as valid GitOps triggers
+in its default configuration. When the HTTP server is enabled (`EnableHTTP`) and
+no webhook secret is configured, the daemon SHALL refuse to start. An operator
+MAY opt out by setting `BOSUN_ALLOW_UNSIGNED_WEBHOOKS=true`, in which case the
+daemon SHALL log a security warning naming the risk on startup and on every
+webhook receipt. When a webhook secret is configured, every webhook entry point
+(`/webhook`, `/webhook/github`, `/webhook/manual`) SHALL reject requests with a
+missing or invalid signature with HTTP 401 and SHALL NOT trigger a reconcile.
+
+#### Scenario: HTTP enabled with no secret refuses to start
+- **WHEN** the daemon starts with `EnableHTTP=true`, an empty `WebhookSecret`, and `BOSUN_ALLOW_UNSIGNED_WEBHOOKS` unset
+- **THEN** startup fails with an error explaining that a webhook secret is required
+- **AND** the HTTP listener never binds
+
+#### Scenario: Explicit opt-in permits unsigned webhooks with a warning
+- **WHEN** the daemon starts with `EnableHTTP=true`, an empty `WebhookSecret`, and `BOSUN_ALLOW_UNSIGNED_WEBHOOKS=true`
+- **THEN** the daemon starts and logs a security warning at startup
+- **AND** each subsequent webhook receipt logs a security warning identifying the request as unauthenticated
+
+#### Scenario: Configured secret rejects unsigned request
+- **WHEN** a webhook secret is configured and a POST arrives at `/webhook`, `/webhook/github`, or `/webhook/manual` with no signature or an invalid signature
+- **THEN** the daemon responds 401
+- **AND** no reconcile is triggered
+
+#### Scenario: Configured secret accepts valid signature
+- **WHEN** a webhook secret is configured and a POST arrives with a valid HMAC-SHA256 signature over the request body
+- **THEN** the daemon responds 202 and triggers a reconcile
+
+### Requirement: Unix socket peer-credential enforcement
+
+The Unix socket server SHALL authorize trigger and control requests by peer
+credentials, not solely by socket file mode. A request SHALL be authorized only
+when the connecting peer's UID is the daemon's own UID or is present in a
+configured allowlist (`BOSUN_SOCKET_ALLOWED_UIDS`). When peer credentials cannot
+be determined for a connection — including platforms without `SO_PEERCRED`
+support — the daemon SHALL deny mutating requests (fail-closed) unless the
+operator has explicitly disabled peer-credential enforcement.
+
+#### Scenario: Non-allowlisted UID is denied
+- **WHEN** a local process whose UID is neither the daemon UID nor in the allowlist sends `POST /trigger`
+- **THEN** the daemon responds 403
+- **AND** no reconcile is triggered
+
+#### Scenario: Daemon-owner UID is allowed
+- **WHEN** a process running as the daemon's own UID sends `POST /trigger`
+- **THEN** the daemon responds 202 and triggers a reconcile
+
+#### Scenario: Peer credentials unavailable fails closed
+- **WHEN** a `POST /trigger` arrives on a connection for which peer credentials cannot be determined
+- **THEN** the daemon responds 403 unless peer-credential enforcement has been explicitly disabled
+
+### Requirement: Socket permission integrity
+
+The Unix socket SHALL be created with its configured file mode
+(`SocketConfig.SocketMode`) and SHALL NOT pass through a more-permissive mode at
+any point between creation and first accept. The configured mode SHALL be
+honored rather than hard-coded.
+
+#### Scenario: Socket honors configured mode with no permissive window
+- **WHEN** the daemon creates its Unix socket with a configured mode of `0600`
+- **THEN** the socket's mode is `0600` from the moment it is observable
+- **AND** at no point is the socket world- or group-connectable before the mode is applied
+
+### Requirement: HTTP request hardening
+
+Every daemon HTTP server SHALL set a finite `ReadHeaderTimeout` and a bounded
+`MaxHeaderBytes`, and every trigger entry point SHALL bound its request body with
+`http.MaxBytesReader`. This applies to the webhook server, the Unix socket HTTP
+server, the TCP API server, and the HTTP API trigger handler, sized to the
+trigger schema.
+
+#### Scenario: Webhook server bounds headers and bodies
+- **WHEN** the webhook HTTP server is constructed
+- **THEN** it sets a finite `ReadHeaderTimeout` and a finite `MaxHeaderBytes`
+- **AND** a slow-header client is disconnected after the timeout
+- **AND** a `/webhook/manual` body exceeding the trigger-body limit is rejected
+
+#### Scenario: Unix socket server bounds headers and bodies
+- **WHEN** the Unix socket HTTP server is constructed
+- **THEN** it sets a finite `ReadHeaderTimeout` and `MaxHeaderBytes`
+- **AND** a `POST /trigger` body exceeding the trigger-body limit is rejected before full decode
+
+#### Scenario: TCP API server bounds headers and bodies
+- **WHEN** the TCP API server is constructed
+- **THEN** it sets a finite `ReadHeaderTimeout` and `MaxHeaderBytes`
+- **AND** a `POST /trigger` body exceeding the trigger-body limit is rejected before full decode
+
+#### Scenario: HTTP API trigger bounds body
+- **WHEN** `handleAPITrigger` decodes a request body
+- **THEN** the body is wrapped in `http.MaxBytesReader` and an oversized payload is rejected
+
+### Requirement: Anonymous endpoint exposure control
+
+The `/metrics` and `/api/widget` endpoints SHALL NOT be reachable by
+unauthenticated remote callers in the daemon's default configuration. These
+endpoints SHALL be served only to localhost, gated behind authentication, or
+enabled by an explicit operator opt-in. The deployed git SHA and reconcile
+cadence SHALL NOT be disclosed to anonymous remote callers by default.
+
+#### Scenario: Widget not remotely reachable by default
+- **WHEN** a remote, unauthenticated caller requests `/api/widget` under the default configuration
+- **THEN** the request is refused (not served the deploy SHA and cadence)
+
+#### Scenario: Metrics not remotely reachable by default
+- **WHEN** a remote, unauthenticated caller requests `/metrics` under the default configuration
+- **THEN** the request is refused
+
+#### Scenario: Explicit opt-in exposes endpoints
+- **WHEN** the operator sets the metrics-exposure opt-in
+- **THEN** `/metrics` and `/api/widget` are served to remote callers as configured
+
+### Requirement: Webhook payload sanitization
+
+Attacker-controlled webhook fields SHALL be length-capped and stripped of
+control characters before being written to logs, recorded in trace span
+attributes, or forwarded to telemetry sinks. This applies to the GitHub pusher
+name and to the reconcile source string derived from it (Sentry and OTEL
+included).
+
+#### Scenario: Oversized pusher name is capped before logging
+- **WHEN** a GitHub push payload carries a pusher name longer than the cap
+- **THEN** the value written to logs, spans, and the reconcile source is truncated to the cap
+
+#### Scenario: Control characters are stripped
+- **WHEN** a pusher name contains newlines, ANSI escapes, or other control characters
+- **THEN** those characters are removed or escaped before the value is logged or sent to telemetry

--- a/openspec/changes/add-daemon-security/tasks.md
+++ b/openspec/changes/add-daemon-security/tasks.md
@@ -1,0 +1,49 @@
+## 1. Webhook authentication fail-closed
+
+- [ ] 1.1 Add `AllowUnsignedWebhooks` to `Config`, parsed from `BOSUN_ALLOW_UNSIGNED_WEBHOOKS` in `ConfigFromEnv`
+- [ ] 1.2 In `ValidateConfig` (daemon.go), fail when `EnableHTTP && WebhookSecret == "" && !AllowUnsignedWebhooks`
+- [ ] 1.3 Log a startup security warning when unsigned webhooks are opted-in
+- [ ] 1.4 Log a per-receipt security warning in `handleWebhook`/`handleGitHubWebhook`/`handleManualTrigger` when serving unauthenticated
+- [ ] 1.5 Confirm `handleManualTrigger`'s secret-less branch is unreachable once the startup gate is in place (or remove it)
+- [ ] 1.6 Tests: startup refusal, opt-in path, 401 on bad signature, 202 on good signature
+
+## 2. Unix socket peer-credential enforcement
+
+- [ ] 2.1 Add `AllowedUIDs` (and enforcement-disable flag) to `SocketConfig`, parsed from `BOSUN_SOCKET_ALLOWED_UIDS`
+- [ ] 2.2 Enforce peer UID in `SocketServer.handleTrigger` (and other mutating handlers) using `InjectPeerCred` context
+- [ ] 2.3 Fail-closed when peer credentials are unavailable (incl. `peercred_other.go` no-op path) unless enforcement is explicitly disabled
+- [ ] 2.4 Tests: denied non-allowlisted UID (403), allowed owner UID (202), unavailable-creds fail-closed
+
+## 3. Socket permission integrity
+
+- [ ] 3.1 Honor `s.cfg.SocketMode` instead of hard-coded `0660` in `socket.go` Start
+- [ ] 3.2 Set umask (or create-then-chmod with no widening) so the socket is never world/group-connectable before its mode is applied
+- [ ] 3.3 Tests: socket initial mode equals configured mode; no permissive window
+
+## 4. HTTP request hardening
+
+- [ ] 4.1 Add `ReadHeaderTimeout` and `MaxHeaderBytes` to the webhook `http.Server` (server.go)
+- [ ] 4.2 Add `ReadHeaderTimeout` and `MaxHeaderBytes` to the socket `http.Server` (socket.go)
+- [ ] 4.3 Add `ReadHeaderTimeout` and `MaxHeaderBytes` to the TCP `http.Server` (tcp.go)
+- [ ] 4.4 Wrap `SocketServer.handleTrigger` body in `http.MaxBytesReader`
+- [ ] 4.5 Wrap `TCPServer.handleTrigger` body in `http.MaxBytesReader`
+- [ ] 4.6 Wrap `handleAPITrigger` body in `http.MaxBytesReader`
+- [ ] 4.7 Tests: slow-header disconnect; oversized body rejected on each of socket/TCP/API trigger
+
+## 5. Anonymous endpoint exposure control
+
+- [ ] 5.1 Add metrics/widget exposure opt-in to `Config`, parsed from env
+- [ ] 5.2 Gate `/metrics` and `/api/widget` to localhost / auth / opt-in in `NewServer`
+- [ ] 5.3 Tests: default refuses remote `/metrics` and `/api/widget`; opt-in serves them
+
+## 6. Webhook payload sanitization
+
+- [ ] 6.1 Add a sanitize helper (length cap + control-char strip) for pusher name
+- [ ] 6.2 Apply it before logging, span attributes, and the `github:%s` source string in `handleGitHubWebhook`
+- [ ] 6.3 Tests: oversized name truncated; control characters stripped
+
+## 7. Documentation
+
+- [ ] 7.1 Update `docs/security.md` with the daemon security posture
+- [ ] 7.2 Update `skills/onboard/resources/gitops.md`
+- [ ] 7.3 Add new env vars to the `CLAUDE.md` env-var table


### PR DESCRIPTION
## Summary

Spec proposal establishing a `daemon-security` capability — a fail-closed-by-default security posture across every daemon entry point. This is **Wave 1** of the bug-hunt remediation plan (Cluster B). Spec-only; no implementation until `ready-to-build`.

Covers six requirements drawn from the April 2026 reconcile-path bug hunt:

| Requirement | Finding | Severity |
|---|---|---|
| Webhook authentication fail-closed | GHSA-q67h-gp7c-rx88 (webhook fail-open) | Critical |
| Unix socket peer-credential enforcement | #253 | P1 |
| Socket permission integrity | #254 | P1 |
| HTTP request hardening (ReadHeaderTimeout, MaxHeaderBytes, body limits) | #255, #295 | P1/P2 |
| Anonymous endpoint exposure control (/metrics, /api/widget) | #296 | P2 |
| Webhook payload sanitization (pusher name) | #297 | P3 |

## What's in the proposal

- `proposal.md` — why, what changes (incl. **BREAKING** secret-less HTTP gate), full impact + consumer list
- `specs/daemon-security/spec.md` — 6 ADDED requirements, scenario-per-consumer for the multi-server requirements
- `tasks.md` — implementation checklist grouped per requirement + per trigger consumer
- `design.md` — fail-closed decisions, escape-hatch flags, migration + rollback

`openspec validate add-daemon-security --strict` passes.

## Review focus

- Are the escape-hatch env vars (`BOSUN_ALLOW_UNSIGNED_WEBHOOKS`, socket UID allowlist, metrics exposure opt-in) the right knobs?
- Is the breaking startup-gate behavior acceptable, or should it be a loud warning + opt-out rather than opt-in?
- Open questions in `design.md` (UID-vs-username, metrics opt-in env-var name).

## Test plan

- [ ] CodeRabbit review converges (0 actionable / stale only)
- [ ] Label `ready-to-build` once stable
- [ ] Implementation tracked separately (Wave 2, Cluster B)

Refs bosun-0rv

🤖 Generated with [Claude Code](https://claude.com/claude-code)