### PR TITLE
docs: fix daemon webhook claims + add llms.txt drift guard (#293)

### DIFF
--- a/.github/workflows/llms-txt-sync.yml
+++ b/.github/workflows/llms-txt-sync.yml
@@ -14,17 +14,28 @@ on:
     types: [opened, synchronize, reopened]
     branches: [main]
 
+# PR-scoped concurrency: a rapid second push (synchronize) cancels the in-flight
+# run, so two runs can't both create the sticky comment before either sees it.
+concurrency:
+  group: llms-txt-sync-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# Least privilege: read-only at the top; the job grants only what it calls.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   nudge:
     name: Check llms.txt freshness
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read   # github.rest.pulls.listFiles
+      issues: write         # PR comments are issue comments (create/update/list)
     steps:
       - name: Evaluate diff and post sticky nudge
-        uses: actions/github-script@v7
+        # Pinned to a commit SHA (supply-chain hardening); tag shown for readability.
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const MARKER = '<!-- llms-txt-nudge -->';

--- a/.github/workflows/llms-txt-sync.yml
+++ b/.github/workflows/llms-txt-sync.yml
@@ -1,0 +1,102 @@
+name: llms.txt Sync Check
+
+# Nudges (does not block) when a PR changes capability-bearing code or claim-bearing
+# docs but leaves llms.txt untouched. Born from #293: instruction files (llms.txt,
+# CLAUDE.md) drifted ahead of the daemon's actual webhook support and actively misled
+# both agents and operators. This keeps the AI-facing summary diffed against reality.
+#
+# Security note: all dynamic values flow through actions/github-script API calls and
+# JS variables — no untrusted input is interpolated into a run: shell. Changed file
+# paths are repo-controlled and rendered inside Markdown code spans.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  nudge:
+    name: Check llms.txt freshness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate diff and post sticky nudge
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const MARKER = '<!-- llms-txt-nudge -->';
+
+            // Paths whose changes commonly invalidate claims in llms.txt.
+            // Capability-bearing code (commands, daemon endpoints, reconcile/manifest
+            // behavior) and the claim-bearing docs that mirror llms.txt.
+            const CLAIM_PATHS = [
+              /^internal\/cmd\//,
+              /^internal\/daemon\//,
+              /^internal\/reconcile\//,
+              /^internal\/manifest\//,
+              /^internal\/config\//,
+              /^cmd\//,
+              /^go\.mod$/,
+              /^README\.md$/,
+              /^docs\//,
+            ];
+
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // Collect every changed file in the PR (paginated).
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: prNumber, per_page: 100,
+            });
+            const changed = files.map(f => f.filename);
+
+            const touchedLlms = changed.includes('llms.txt');
+            const touchedClaims = changed.filter(f => CLAIM_PATHS.some(rx => rx.test(f)));
+            const shouldNudge = touchedClaims.length > 0 && !touchedLlms;
+
+            // Find a prior nudge comment so we update in place instead of stacking.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+
+            if (shouldNudge) {
+              const sample = touchedClaims.slice(0, 10).map(f => `- \`${f}\``).join('\n');
+              const more = touchedClaims.length > 10 ? `\n- …and ${touchedClaims.length - 10} more` : '';
+              const body = [
+                MARKER,
+                '### 🪢 Does `llms.txt` need an update?',
+                '',
+                'This PR changes capability-bearing code or claim-bearing docs, but does not touch `llms.txt`.',
+                '',
+                '`llms.txt` is the AI-facing summary of what Bosun does. When the daemon, commands, or docs change, its claims can silently drift ahead of reality (see #293). Please confirm its statements still match the code — commands, daemon endpoints, supported providers, version requirements.',
+                '',
+                '<details><summary>Changed paths that triggered this</summary>',
+                '',
+                `${sample}${more}`,
+                '',
+                '</details>',
+                '',
+                '_If `llms.txt` is already accurate, no action needed — this is a reminder, not a gate._',
+              ].join('\n');
+
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+              }
+            } else if (existing) {
+              // Condition cleared (llms.txt now updated, or no claim paths left) — resolve the nudge.
+              const resolved = [
+                MARKER,
+                '### 🪢 `llms.txt` check',
+                '',
+                touchedLlms
+                  ? '✅ `llms.txt` was updated in this PR. Thanks for keeping the AI-facing summary in sync.'
+                  : '✅ No capability- or claim-bearing paths remain changed. Nothing to reconcile against `llms.txt`.',
+              ].join('\n');
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: resolved });
+            }

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ bosun daemon
 The daemon provides:
 
 - **Unix socket API** at `/var/run/bosun.sock`
-- **Multi-provider webhooks** (GitHub, GitLab, Gitea, Bitbucket)
+- **GitHub webhooks** (`/webhook/github`) and a generic HMAC endpoint (`/webhook`). GitLab, Gitea, and Bitbucket run through the separate `bosun webhook` receiver, which normalizes each provider and forwards to the daemon
 - **Configurable polling** with interval-based reconciliation
 - **Health endpoints** (`/health`, `/ready`) for orchestrators
 - **Drift detection** with periodic declared-vs-actual state checks
@@ -341,7 +341,7 @@ Everything uses nautical terminology:
 
 | ADR | Summary |
 |-----|---------|
-| [Daemon Architecture](docs/architecture/daemon-split.md) | Unix socket API, multi-provider webhooks |
+| [Daemon Architecture](docs/architecture/daemon-split.md) | Unix socket API, webhook reception, standalone receiver split |
 | [Council Review](docs/architecture/council-review.md) | Security-first daemon design (9/10) |
 | [0001: Manifest System](docs/adr/0001-manifest-system.md) | DRY crew provisioning |
 | [0008: Container vs Daemon](docs/adr/0008-container-vs-daemon.md) | When to use systemd |
@@ -350,7 +350,7 @@ Everything uses nautical terminology:
 
 ## Requirements
 
-- **Go 1.24+** (building from source)
+- **Go 1.25+** (building from source)
 - **Docker + Docker Compose v2**
 - **Git** (for reconcile workflow)
 - **SOPS + Age** (for secret encryption)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -497,11 +497,14 @@ bosun daemon -i 1800
 |------|--------|-------------|
 | `/health` | GET | Health check (JSON) |
 | `/ready` | GET | Readiness check |
-| `/webhook` | POST | Generic webhook trigger |
+| `/webhook` | POST | Generic webhook trigger (validates `X-Signature` or `X-Hub-Signature-256`) |
 | `/webhook/github` | POST | GitHub push webhook |
-| `/webhook/gitlab` | POST | GitLab push webhook |
-| `/webhook/gitea` | POST | Gitea push webhook |
-| `/webhook/bitbucket` | POST | Bitbucket push webhook |
+| `/webhook/manual` | POST | Manual trigger |
+| `/metrics` | GET | Prometheus metrics |
+
+GitLab, Gitea, and Bitbucket are **not** served by the daemon directly — use the
+standalone `bosun webhook` receiver (see below), which forwards normalized triggers
+to the daemon.
 
 ### trigger
 

--- a/docs/gitops.md
+++ b/docs/gitops.md
@@ -70,16 +70,28 @@ bosun validate                   # Validate config and connectivity
 
 ### Webhook Providers
 
-The daemon accepts webhooks from multiple Git providers at `/webhook/{provider}`:
+The daemon itself serves two webhook endpoints:
 
-| Provider | Path | Signature Header |
+| Endpoint | Path | Signature Header |
 |----------|------|------------------|
+| GitHub | `/webhook/github` | `X-Hub-Signature-256` |
+| Generic | `/webhook` | `X-Signature`, or `X-Hub-Signature-256` |
+
+GitLab, Gitea, and Bitbucket are **not** handled directly by the daemon. To receive
+them, run the standalone `bosun webhook` receiver, which understands each provider's
+signature scheme and forwards normalized triggers to the daemon over its Unix socket:
+
+| Provider | Path (receiver) | Signature Header |
+|----------|-----------------|------------------|
 | GitHub | `/webhook/github` | `X-Hub-Signature-256` |
 | GitLab | `/webhook/gitlab` | `X-Gitlab-Token` |
 | Gitea | `/webhook/gitea` | `X-Gitea-Signature` |
 | Bitbucket | `/webhook/bitbucket` | `X-Hub-Signature` |
 
-Signatures are validated using HMAC-SHA256 (or SHA1 for legacy) with constant-time comparison.
+Do not point a Gitea/GitLab/Bitbucket webhook directly at the daemon's `/webhook`
+endpoint — its generic handler expects `X-Signature`/`X-Hub-Signature-256`, so a
+provider-specific signature header will fail validation. Signatures are validated
+using HMAC-SHA256 (or SHA1 for legacy) with constant-time comparison.
 
 ### Polling Mode
 

--- a/llms.txt
+++ b/llms.txt
@@ -60,7 +60,7 @@ docker compose up -> post-deploy drift verification
 
 The daemon provides:
 - Unix socket API at `/var/run/bosun.sock`
-- Multi-provider webhooks (GitHub, GitLab, Gitea, Bitbucket)
+- GitHub webhooks (`/webhook/github`) plus a generic HMAC endpoint (`/webhook`, validates `X-Signature` or `X-Hub-Signature-256`). GitLab, Gitea, and Bitbucket are handled by the separate `bosun webhook` receiver, which normalizes each provider and forwards to the daemon's trigger endpoint — do not point them directly at the daemon
 - Configurable polling intervals
 - Health endpoints (`/health`, `/ready`)
 - Periodic drift detection (declared vs actual state)
@@ -87,7 +87,7 @@ bosun/
 
 ## Technology Stack
 
-- Go 1.24+
+- Go 1.25+
 - Docker + Docker Compose v2
 - SOPS + Age (secret encryption)
 - Go text/template + Sprig (templating)

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -12,7 +12,7 @@ Bosun is a GitOps CLI tool for Docker Compose on bare metal - "Helm for home." I
 
 ## Tech Stack
 
-- **Language:** Go 1.24+
+- **Language:** Go 1.25+
 - **CLI Framework:** Cobra (`github.com/spf13/cobra`)
 - **Container Runtime:** Docker + Docker Compose v2 (`github.com/docker/docker`)
 - **Secret Management:** SOPS + Age (`github.com/getsops/sops/v3`, `filippo.io/age`)
@@ -124,7 +124,7 @@ template configs (chezmoi) -> rsync to target -> docker compose up
 - **Git Repository:** Source of truth for configurations
 - **SOPS/Age:** Optional secret encryption
 - **Chezmoi:** Optional templating engine (external binary)
-- **Webhook Providers:** GitHub, GitLab, Gitea, Bitbucket for push notifications
+- **Webhook Providers:** Daemon serves GitHub + a generic HMAC endpoint; the standalone `bosun webhook` receiver adds GitLab, Gitea, and Bitbucket and forwards to the daemon
 
 ## Build Commands
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bosun
+name: onboard
 description: "Get started with Bosun -- what it is, how to set it up, and how to use it"
 ---
 
@@ -32,7 +32,7 @@ Before setting up Bosun, ensure the following are installed:
 - **Docker + Docker Compose v2** -- `docker compose version` to verify
 - **Git** -- for repository operations
 - **SOPS + Age** -- for secret encryption (`age-keygen` to generate keys, `sops` CLI for encryption)
-- **Go 1.24+** -- only if building from source
+- **Go 1.25+** -- only if building from source
 - **Linux or macOS** -- tested on Unraid, Debian, Ubuntu, macOS
 - **Tailscale** (optional) -- for webhook tunnel via `bosun radio`
 

--- a/skills/onboard/resources/gitops.md
+++ b/skills/onboard/resources/gitops.md
@@ -225,24 +225,34 @@ Single-flight with dirty flag coalescing:
 
 ## Webhooks
 
-The daemon accepts webhooks from Git providers to trigger reconciliation on push.
+The daemon accepts webhooks to trigger reconciliation on push.
 
-### Webhook Endpoints
+### Daemon Webhook Endpoints
 
-| Provider | Path | Signature Header |
+The daemon serves GitHub and a generic HMAC endpoint:
+
+| Endpoint | Path | Signature Header |
 |----------|------|------------------|
+| GitHub | `/webhook/github` | `X-Hub-Signature-256` |
+| Generic | `/webhook` | `X-Signature`, or `X-Hub-Signature-256` |
+
+GitLab, Gitea, and Bitbucket are **not** handled by the daemon directly. Point them
+at the standalone `bosun webhook` receiver (below), which understands each provider
+and forwards normalized triggers to the daemon:
+
+| Provider | Path (receiver) | Signature Header |
+|----------|-----------------|------------------|
 | GitHub | `/webhook/github` | `X-Hub-Signature-256` |
 | GitLab | `/webhook/gitlab` | `X-Gitlab-Token` |
 | Gitea | `/webhook/gitea` | `X-Gitea-Signature` |
 | Bitbucket | `/webhook/bitbucket` | `X-Hub-Signature` |
-| Generic | `/webhook` | None |
 
 All signatures are validated using HMAC-SHA256 (or SHA1 for legacy) with constant-time comparison.
 
 ### Webhook Setup
 
 1. **Configure a webhook secret** in your bosun environment
-2. **Set up the webhook** in your Git provider pointing to `https://your-server/webhook/github` (or appropriate provider)
+2. **Set up the webhook** in your Git provider. For GitHub, point it at `https://your-server/webhook/github`. For GitLab/Gitea/Bitbucket, run the standalone `bosun webhook` receiver and point the provider at its provider-specific path
 3. **Expose the endpoint** via Tailscale Funnel or Cloudflare Tunnel (see Radio commands)
 
 ### Standalone Webhook Server


### PR DESCRIPTION
## What

Full claims-vs-code audit of `llms.txt` (and the docs that mirror it), prompted by #293 and the external comment that our instruction files assert capabilities the daemon doesn't have — actively misleading both agents and operators.

## Findings

Two claims in `llms.txt` were wrong, and both had drifted repo-wide:

1. **"Multi-provider webhooks (GitHub, GitLab, Gitea, Bitbucket)" attributed to the daemon** — false. The daemon (`internal/daemon/server.go`) registers only `/webhook` (generic HMAC, checks `X-Signature` → `X-Hub-Signature-256`), `/webhook/github`, and `/webhook/manual`. Multi-provider parsing lives in the **standalone `bosun webhook` receiver** (`internal/cmd/webhook.go`), which normalizes each provider and forwards to the daemon. Pointing Gitea/GitLab/Bitbucket directly at the daemon hits a signature-header mismatch — the exact path that nudges operators toward emptying the secret (fail-open).
2. **"Go 1.24+"** — stale; `go.mod` declares `go 1.25.0`.

Everything else verified accurate: all doc links resolve, all referenced commands exist, socket path, `/health` `/ready`, circuit-breaker-after-3 (`MaxAttempts = 3`).

## Changes

- **Docs** — corrected the daemon-vs-receiver webhook framing in `llms.txt`, `README.md`, `docs/gitops.md`, `docs/commands.md` (its daemon endpoint table also wrongly listed provider routes and omitted the real `/webhook/manual`), `skills/onboard/resources/gitops.md`, and `openspec/project.md`. Bumped Go 1.24→1.25 in the doc copies.
- **Skill fix** — `skills/onboard/SKILL.md` declared `name: bosun` (the plugin name) instead of `onboard`, failing the name-matches-directory convention. Renamed, plus the Go bump.
- **CI guard** — new non-blocking `.github/workflows/llms-txt-sync.yml`: a sticky-comment Action that nudges PRs which change capability-bearing code or claim-bearing docs without updating `llms.txt`. Addresses the commenter's root cause (nothing diffs the claims against reality). `actionlint`-clean.

## Deliberately unchanged

`docs/architecture/decisions.md` and `docs/architecture/bosun-architecture-review.md` also list per-provider webhook tables, but both correctly attribute them to the `bosun webhook` **container/receiver**, not the daemon — so the design record is accurate and left intact. `CHANGELOG.md` history untouched.

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
