### PR TITLE
spec: add-daemon-lifecycle — bounded/cancellable/lossless reconcile (Cluster I)

### DIFF
--- a/openspec/changes/add-daemon-lifecycle/design.md
+++ b/openspec/changes/add-daemon-lifecycle/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The daemon runs a single-flight reconcile loop with dirty-flag coalescing. Five
+entry points can trigger a reconcile: startup, poll, HTTP webhook, Unix socket,
+and TCP API (plus the `/api/trigger` handler). These evolved independently, so
+the timeout/cancellation/queueing contract differs per entry point. The webhook
+path wraps `context.WithTimeout`; startup and poll do not. The socket/TCP/api
+paths spawn `context.Background()` goroutines that outlive shutdown. The
+coalescing logic uses a boolean dirty-flag that loses concurrent triggers.
+
+## Goals / Non-Goals
+
+- Goals:
+  - One uniform reconcile execution envelope: bounded, cancellable, queue-safe.
+  - Enforce the timeout at a single chokepoint so it cannot be bypassed.
+  - Make shutdown deterministic — no orphaned reconcile after exit.
+- Non-Goals:
+  - Reordering or prioritizing triggers beyond "don't lose them."
+  - SSH/tar subprocess orphan cleanup (Cluster H).
+  - Lock-directory bootstrap (#241, plain bug fix).
+
+## Decisions
+
+- **Decision: Enforce `ReconcileTimeout` inside `executeReconcile`.**
+  Wrapping at each call site is the source of the #231 gap — a new entry point
+  silently lacks the bound. Centralizing makes the invariant structural.
+  - Alternatives: add the wrap at the two missing call sites only (fragile,
+    invites recurrence).
+
+- **Decision: Daemon-wide cancellation context + WaitGroup for all spawns.**
+  The webhook path already uses `d.wg`; extend the same pattern to socket/TCP/api
+  and derive every spawned context from a daemon root context that Shutdown
+  cancels. Reuses the existing graceful-shutdown machinery in `Server.Shutdown`.
+
+- **Decision: Counter/queue coalescing over dirty-bit.**
+  A monotonically-checked counter (or a bounded source-capturing queue) closes
+  the lost-update window between `executeReconcile` completion and clearing
+  `reconciling`. Source attribution becomes an aggregate, not a last-writer.
+
+- **Decision: `cmd.Cancel` with SIGTERM→grace→SIGKILL for docker.**
+  The docker CLI is a thin gRPC client; SIGKILLing it abandons server-side work.
+  A graceful cancel (or compose-down on timeout) makes "cancelled" mean the
+  docker daemon actually stopped. Trade-off: a small extra shutdown delay.
+
+## Risks / Trade-offs
+
+- **Centralizing the timeout could double-bound paths that already wrap it** →
+  audit and remove redundant wraps; nested identical timeouts are harmless but
+  untidy.
+- **Counter-based coalescing adds concurrency surface** → cover with a stress
+  test (100 concurrent triggers during a long reconcile).
+- **Active docker abort adds shutdown latency** → bound it by `ShutdownTimeout`.
+
+## Migration Plan
+
+No config or API change. Behavior change: wedged reconciles now self-cancel at
+`ReconcileTimeout` instead of hanging; operators relying on the old "hang forever"
+behavior (none expected) would notice timeouts in logs. Rollback is reverting the
+code; no state migration.
+
+## Open Questions
+
+- Should coalescing aggregate sources into a single string or keep a small ring
+  of the last N? (Lean: aggregate distinct sources, cap length.)
+- Does compose-down-on-timeout risk tearing down healthy containers from a prior
+  good deploy? (Need to scope abort to the in-flight `up` only.)

--- a/openspec/changes/add-daemon-lifecycle/proposal.md
+++ b/openspec/changes/add-daemon-lifecycle/proposal.md
@@ -1,0 +1,68 @@
+# Change: Daemon reconcile lifecycle — bounded execution, graceful shutdown, lossless coalescing
+
+## Why
+
+The April 2026 reconcile-path bug hunt found that the daemon's reconcile
+lifecycle has no uniform contract for how a reconcile is bounded, cancelled, or
+queued. The webhook, socket, and TCP entry points each wrap reconcile in
+`context.WithTimeout(bgCtx, ReconcileTimeout)`, but the **startup** and **poll**
+triggers pass the bare daemon context with no timeout (#231) — a single wedged
+`docker compose up` or stuck SSH stalls every future GitOps cycle forever, with
+`d.reconciling` stuck true so later triggers coalesce but never run. Separately,
+the socket/TCP/`/api/trigger` paths spawn fire-and-forget goroutines with
+`context.Background()` that ignore daemon shutdown (#256), so SIGTERM mid-deploy
+leaves a reconcile running against shutting-down state. The dirty-flag coalescing
+loses triggers that arrive during a run and overwrites source attribution (#257),
+silently dropping real upstream pushes under load. And when a reconcile times
+out, Go SIGKILLs only the thin docker CLI client — the docker daemon keeps
+pulling/starting in the background (#264), diverging actual state from what bosun
+believes it cancelled.
+
+No spec describes the daemon's lifecycle guarantees, so these are uncovered
+implementation gaps. This proposal establishes a `daemon-lifecycle` capability:
+**every reconcile is bounded, every in-flight reconcile is cancellable at
+shutdown, no trigger is silently dropped, and cancellation aborts external work.**
+
+## What Changes
+
+- **Bounded reconcile execution on every trigger** — the `ReconcileTimeout`
+  bound SHALL apply uniformly to all triggers (startup, poll, webhook, socket,
+  TCP, manual), preferably enforced inside `executeReconcile` so the bound cannot
+  be bypassed by a new entry point.
+- **Graceful shutdown of in-flight reconciles** — every reconcile-spawning path
+  SHALL join the daemon WaitGroup and derive its context from the daemon-wide
+  cancellation context, so shutdown cancels and waits for in-flight work.
+- **Lossless trigger coalescing** — concurrent triggers arriving during an
+  active reconcile SHALL NOT be lost, and the source attribution of a coalesced
+  run SHALL be preserved rather than overwritten.
+- **Cancellation aborts external work** — when a reconcile context expires or is
+  cancelled, the daemon SHALL actively abort in-flight subprocess work (docker
+  compose) rather than only SIGKILLing the local CLI client.
+
+## Impact
+
+- Affected specs: NEW capability `daemon-lifecycle`. Adjacent to `reconcile`
+  (which owns the pipeline steps) but distinct — this is the orchestration
+  envelope around a reconcile run.
+- Affected code:
+  - `internal/daemon/daemon.go` — startup trigger (`:318`), poll trigger
+    (`:674`), `executeReconcile`, dirty-flag coalescing (`:451-523`), `d.wg`,
+    daemon cancellation context
+  - `internal/daemon/server.go` / `api.go` / `socket.go` / `tcp.go` — the
+    reconcile-spawning goroutines (`server.go:231`, `api.go:309`,
+    `socket.go:175`, `tcp.go:169`)
+  - `internal/reconcile/compose.go` — `exec.CommandContext` sites (`:77`, `:235`,
+    `:326`, `:360`) needing `cmd.Cancel` / active abort
+- All trigger consumers (each needs its own scenario + task):
+  - startup trigger (`daemon.go:318`)
+  - poll trigger (`daemon.go:674`)
+  - webhook / socket / TCP / API trigger goroutines
+- New config / env vars: none new — formalizes use of existing
+  `BOSUN_RECONCILE_TIMEOUT` and `BOSUN_SHUTDOWN_TIMEOUT`.
+- Out of scope (handled elsewhere):
+  - SSH/tar orphan-process cleanup on cancel (#251, #276) — Cluster H
+    (reconcile/SSH lifecycle)
+  - Lock-directory bootstrap (#241) — plain bug fix (restores intended
+    behavior), no spec proposal
+- Docs: `skills/onboard/resources/gitops.md` (daemon reconcile lifecycle),
+  `docs/troubleshooting.md` (wedged-reconcile recovery).

--- a/openspec/changes/add-daemon-lifecycle/specs/daemon-lifecycle/spec.md
+++ b/openspec/changes/add-daemon-lifecycle/specs/daemon-lifecycle/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Bounded reconcile execution
+
+Every reconcile SHALL execute under a finite timeout derived from
+`ReconcileTimeout`, regardless of which trigger initiated it. The bound SHALL be
+enforced at a single chokepoint (`executeReconcile`) so that startup, poll,
+webhook, socket, TCP, and manual triggers are all bounded uniformly and a new
+entry point cannot bypass it. A reconcile that exceeds the timeout SHALL be
+cancelled and reported as a timeout error, and the daemon's `reconciling` state
+SHALL be cleared so subsequent triggers can run.
+
+#### Scenario: Poll-triggered reconcile is bounded
+- **WHEN** a poll-triggered reconcile exceeds `ReconcileTimeout`
+- **THEN** the reconcile is cancelled and reported as a timeout error
+- **AND** the daemon accepts and runs the next trigger rather than wedging
+
+#### Scenario: Startup-triggered reconcile is bounded
+- **WHEN** the startup reconcile exceeds `ReconcileTimeout`
+- **THEN** the reconcile is cancelled and reported as a timeout error
+- **AND** the daemon continues to its poll/serve loop
+
+#### Scenario: A wedged reconcile does not block future cycles
+- **WHEN** one reconcile is cancelled at the timeout boundary
+- **THEN** `reconciling` is cleared and a later webhook or manual trigger executes normally
+
+### Requirement: Graceful shutdown of in-flight reconciles
+
+Every code path that spawns a reconcile SHALL register with the daemon's
+WaitGroup and SHALL derive its context from the daemon-wide cancellation context,
+so that daemon shutdown cancels in-flight reconciles and waits for them to unwind
+within the shutdown timeout. No reconcile SHALL be spawned from a detached
+`context.Background()` that ignores shutdown.
+
+#### Scenario: SIGTERM cancels a socket-triggered reconcile
+- **WHEN** a reconcile triggered via the Unix socket is in flight and the daemon receives SIGTERM
+- **THEN** the reconcile's context is cancelled
+- **AND** shutdown waits for the goroutine to return before exiting
+
+#### Scenario: SIGTERM cancels a TCP-triggered reconcile
+- **WHEN** a reconcile triggered via the TCP API is in flight and the daemon receives SIGTERM
+- **THEN** the reconcile's context is cancelled and shutdown waits for it
+
+#### Scenario: SIGTERM cancels an API-triggered reconcile
+- **WHEN** a reconcile triggered via `/api/trigger` is in flight and the daemon receives SIGTERM
+- **THEN** the reconcile's context is cancelled and shutdown waits for it
+
+### Requirement: Lossless trigger coalescing
+
+The daemon SHALL NOT silently drop a trigger that arrives while a reconcile is
+running. When triggers are coalesced, the daemon SHALL guarantee that at least
+one further reconcile runs after the current one if any trigger arrived during
+it, and SHALL preserve the source attribution of coalesced triggers rather than
+overwriting it with the most recent value.
+
+#### Scenario: Trigger arriving mid-reconcile is not lost
+- **WHEN** a reconcile is running and a new trigger arrives before it completes
+- **THEN** the daemon runs a follow-up reconcile after the current one completes
+
+#### Scenario: Concurrent triggers preserve source attribution
+- **WHEN** multiple triggers from different sources arrive during one reconcile
+- **THEN** the coalesced run records the contributing sources rather than only the last writer
+
+### Requirement: Cancellation aborts external work
+
+When a reconcile context expires or is cancelled, the daemon SHALL actively
+abort in-flight external subprocess work rather than relying solely on SIGKILL of
+the local CLI client. For `docker compose` invocations, the daemon SHALL ensure
+the underlying docker operation is stopped (e.g. graceful SIGTERM-then-SIGKILL or
+an explicit compose-down) so that actual container state does not continue to
+diverge after the reconcile is considered cancelled.
+
+#### Scenario: Timeout during compose up does not leak background work
+- **WHEN** `docker compose up` is in flight and the reconcile timeout fires
+- **THEN** the docker operation is actively aborted
+- **AND** the docker daemon does not continue bringing up containers after the reconcile is reported cancelled

--- a/openspec/changes/add-daemon-lifecycle/tasks.md
+++ b/openspec/changes/add-daemon-lifecycle/tasks.md
@@ -1,0 +1,35 @@
+## 1. Bounded reconcile execution
+
+- [ ] 1.1 Move the `context.WithTimeout(.., ReconcileTimeout)` bound into `executeReconcile` (single chokepoint)
+- [ ] 1.2 Remove now-redundant per-entry-point timeout wrapping (webhook/socket/TCP/api) or confirm it composes safely
+- [ ] 1.3 Wrap the startup trigger (daemon.go:318) so it inherits the bound
+- [ ] 1.4 Wrap the poll trigger (daemon.go:674) so it inherits the bound
+- [ ] 1.5 Ensure `reconciling` is cleared on timeout/cancel (defer)
+- [ ] 1.6 Tests: induced hang on poll and startup errors at timeout; subsequent trigger runs
+
+## 2. Graceful shutdown of in-flight reconciles
+
+- [ ] 2.1 Add a daemon-wide cancellation context that Shutdown cancels
+- [ ] 2.2 Socket trigger goroutine joins `d.wg` and derives ctx from daemon ctx (socket.go:175)
+- [ ] 2.3 TCP trigger goroutine joins `d.wg` and derives ctx from daemon ctx (tcp.go:169)
+- [ ] 2.4 API trigger goroutine joins `d.wg` and derives ctx from daemon ctx (api.go:309)
+- [ ] 2.5 Shutdown waits on `d.wg` within `ShutdownTimeout`
+- [ ] 2.6 Tests: SIGTERM cancels in-flight socket/TCP/API reconciles
+
+## 3. Lossless trigger coalescing
+
+- [ ] 3.1 Replace the dirty-bit with a counter or small queue capturing source per trigger (daemon.go:451-523)
+- [ ] 3.2 After each reconcile, atomically re-check the counter before clearing `reconciling`
+- [ ] 3.3 Preserve/aggregate source attribution across coalesced triggers
+- [ ] 3.4 Stress test: many concurrent triggers during a long reconcile; assert no trigger lost and sources recorded
+
+## 4. Cancellation aborts external work
+
+- [ ] 4.1 Set `cmd.Cancel` (SIGTERM, grace, then SIGKILL) or compose-down on the `exec.CommandContext` sites (compose.go:77,235,326,360)
+- [ ] 4.2 Verify the docker operation stops, not just the CLI client
+- [ ] 4.3 Tests: forced compose-up timeout no longer leaves background container startup
+
+## 5. Documentation
+
+- [ ] 5.1 Update `skills/onboard/resources/gitops.md` (daemon reconcile lifecycle guarantees)
+- [ ] 5.2 Update `docs/troubleshooting.md` (wedged-reconcile recovery now automatic at timeout)


### PR DESCRIPTION
## Summary

Spec proposal for a `daemon-lifecycle` capability — a uniform contract for how the daemon bounds, cancels, and queues reconciles. **Wave 1**, Cluster I. Spec-only; no implementation until `ready-to-build`.

| Requirement | Finding | Severity |
|---|---|---|
| Bounded reconcile execution (single chokepoint) | #231 (no timeout on startup/poll — wedged reconcile blocks daemon forever) | P0 |
| Graceful shutdown of in-flight reconciles | #256 (fire-and-forget goroutines ignore shutdown) | P1 |
| Lossless trigger coalescing | #257 (dirty-flag drops triggers, loses source attribution) | P1 |
| Cancellation aborts external work | #264 (SIGKILL of docker CLI doesn't abort daemon-side pull/start) | P1 |

## Design highlights

- Enforce `ReconcileTimeout` **inside `executeReconcile`** (one chokepoint) so the #231 class can't recur via a new entry point.
- Reuse the existing `d.wg` + a daemon-wide cancellation context for socket/TCP/api spawns.
- Replace the dirty-bit with a counter/queue to close the lost-trigger window.
- `cmd.Cancel` SIGTERM→grace→SIGKILL (or compose-down) so "cancelled" means docker actually stopped.

## Explicitly out of scope

- #241 (lock-dir bootstrap) — plain bug fix, no spec.
- #251 / #276 (SSH/tar orphan cleanup) — Cluster H.

`openspec validate add-daemon-lifecycle --strict` passes.

## Test plan

- [ ] CodeRabbit review converges
- [ ] Label `ready-to-build`
- [ ] Implementation tracked separately (Wave 2, Cluster I — daemon.go merge order B→**I**→F→H→D→E→C)

Refs bosun-uot

🤖 Generated with [Claude Code](https://claude.com/claude-code)