### PR TITLE
feat(reconcile): suggest BOSUN_INFRA_DIR when compose dir is missing (GH#214 Layer 3)

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -86,6 +86,8 @@ var ErrDeployInvariantMissingFile   = errors.New("deploy invariant: destination 
 
 **Purpose**: Surface the silent-success failure mode where reconcile reports success but no files actually land on disk. `ErrComposeDirMissing` is always fatal (misconfigured staging path); `ErrNoDeclaredServices` is overridable via `BOSUN_ALLOW_EMPTY_DECLARED_STATE=true` for genuinely empty repos. The `ErrDeployInvariant*` set is overridable via `BOSUN_SKIP_DEPLOY_INVARIANT=true` for diagnostic deploys (logged at `Warn` with `override=true`).
 
+When `ErrComposeDirMissing` fires, the reconciler scans the infra dir's sibling directories for one containing `compose/` and, if found, appends a `BOSUN_INFRA_DIR=<dir>` suggestion to the surfaced error (GH#214 — `BOSUN_INFRA_DIR="."` while infra was nested under `unraid/`). The hint is diagnostic only; the failure remains unconditional.
+
 **When Returned**:
 - `ErrComposeDirMissing` / `ErrNoDeclaredServices` — from `ExtractDeclaredState` between stages 5 and 7 of the pipeline.
 - `ErrDeployInvariant*` — from the post-deploy invariant gate at stage 9, before `docker compose up` runs.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,7 +43,15 @@ If `bosun reconcile` returns `success: true` and `docker compose up` exits 0, bu
 The render step produced no parseable services in `<staging>/compose/`. Either templates failed to write to the expected location, the compose dir is genuinely empty, or all files in it are unparseable YAML.
 
 - For genuinely empty repos: set `BOSUN_ALLOW_EMPTY_DECLARED_STATE=true` to opt out — the reconciler will log at `Warn` level (with `override=true`) and continue.
-- For misconfigured staging paths (compose dir missing entirely): the error is unconditionally fatal — no override applies. Check `BOSUN_INFRA_DIR` and the rendered staging tree.
+- For misconfigured staging paths (compose dir missing entirely): the error is unconditionally fatal — no override applies. Check `BOSUN_INFRA_DIR` and the rendered staging tree. When the configured infra dir has no `compose/` but a sibling directory does, the error now names the candidate and suggests the fix, e.g.:
+
+  ```
+  declared-state invariant: staging compose directory does not exist:
+  /app/staging/compose (compose/ found under sibling dir(s): unraid)
+  — did you mean BOSUN_INFRA_DIR=unraid?
+  ```
+
+  This is the GH#214 root cause: `BOSUN_INFRA_DIR="."` while `compose/` and `appdata/` live under `unraid/`. Set `BOSUN_INFRA_DIR` to the named directory so render, discovery, and deploy all resolve the same infra root.
 
 **Invariant 2 — `deploy invariant: source has files but no writes recorded` / `destination file has stale mtime`**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,10 +45,10 @@ The render step produced no parseable services in `<staging>/compose/`. Either t
 - For genuinely empty repos: set `BOSUN_ALLOW_EMPTY_DECLARED_STATE=true` to opt out — the reconciler will log at `Warn` level (with `override=true`) and continue.
 - For misconfigured staging paths (compose dir missing entirely): the error is unconditionally fatal — no override applies. Check `BOSUN_INFRA_DIR` and the rendered staging tree. When the configured infra dir has no `compose/` but a sibling directory does, the error now names the candidate and suggests the fix, e.g.:
 
-  ```
+  ```text
   declared-state invariant: staging compose directory does not exist:
   /app/staging/compose (compose/ found under sibling dir(s): unraid)
-  — did you mean BOSUN_INFRA_DIR=unraid?
+  — did you mean BOSUN_INFRA_DIR="unraid"?
   ```
 
   This is the GH#214 root cause: `BOSUN_INFRA_DIR="."` while `compose/` and `appdata/` live under `unraid/`. Set `BOSUN_INFRA_DIR` to the named directory so render, discovery, and deploy all resolve the same infra root.

--- a/internal/reconcile/drift.go
+++ b/internal/reconcile/drift.go
@@ -88,6 +88,31 @@ var ErrComposeDirMissing = errors.New("staging compose directory does not exist"
 // repos (early scaffolding, archive branches).
 var ErrNoDeclaredServices = errors.New("no declared services in staging compose directory")
 
+// findComposeCandidates returns the names of immediate child directories of dir
+// that themselves contain a compose/ subdirectory. Dot-prefixed children are
+// skipped (never legitimate infra roots), and a "compose" entry that is a file
+// rather than a directory does not count. Used to suggest a likely
+// BOSUN_INFRA_DIR when the configured compose directory is missing (GH#214).
+// Results are sorted for deterministic suggestions.
+func findComposeCandidates(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var candidates []string
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		composeInfo, statErr := os.Stat(filepath.Join(dir, entry.Name(), "compose"))
+		if statErr == nil && composeInfo.IsDir() {
+			candidates = append(candidates, entry.Name())
+		}
+	}
+	sort.Strings(candidates)
+	return candidates
+}
+
 // ExtractDeclaredState parses rendered compose files from a staging directory
 // and returns the list of declared services with their images.
 //
@@ -103,9 +128,15 @@ func ExtractDeclaredState(stagingDir string) ([]DeclaredService, error) {
 	// failure modes have different remediation paths.
 	if _, statErr := os.Stat(composeDir); statErr != nil {
 		if os.IsNotExist(statErr) {
+			candidates := findComposeCandidates(stagingDir)
 			logger.Debug().
 				Str(log.FieldPath, composeDir).
+				Strs("candidate_infra_dirs", candidates).
 				Msg("Compose directory does not exist")
+			if len(candidates) > 0 {
+				return nil, fmt.Errorf("%w: %s (compose/ found under sibling dir(s): %s)",
+					ErrComposeDirMissing, composeDir, strings.Join(candidates, ", "))
+			}
 			return nil, fmt.Errorf("%w: %s", ErrComposeDirMissing, composeDir)
 		}
 		return nil, fmt.Errorf("stat compose dir: %w", statErr)

--- a/internal/reconcile/drift_test.go
+++ b/internal/reconcile/drift_test.go
@@ -312,6 +312,56 @@ func TestExtractDeclaredState_NoComposeDir(t *testing.T) {
 	assert.Empty(t, declared)
 }
 
+func TestFindComposeCandidates_SingleCandidate(t *testing.T) {
+	base := t.TempDir()
+	mkdirs(t, base, "unraid/compose", "docs", "scripts")
+
+	got := findComposeCandidates(base)
+	assert.Equal(t, []string{"unraid"}, got)
+}
+
+func TestFindComposeCandidates_MultipleCandidates(t *testing.T) {
+	base := t.TempDir()
+	mkdirs(t, base, "unraid/compose", "staging/compose", "docs")
+
+	got := findComposeCandidates(base)
+	// Sorted for deterministic suggestions.
+	assert.Equal(t, []string{"staging", "unraid"}, got)
+}
+
+func TestFindComposeCandidates_NoCandidate_Empty(t *testing.T) {
+	base := t.TempDir()
+	mkdirs(t, base, "docs", "scripts")
+
+	got := findComposeCandidates(base)
+	assert.Empty(t, got)
+}
+
+func TestFindComposeCandidates_SkipsDotDirsAndComposeFile(t *testing.T) {
+	base := t.TempDir()
+	// .beads/compose is a dot-dir (excluded); good/compose is legit;
+	// filey/compose is a file, not a directory (excluded).
+	mkdirs(t, base, ".beads/compose", "good/compose", "filey")
+	require.NoError(t, os.WriteFile(filepath.Join(base, "filey", "compose"), []byte("x"), 0644))
+
+	got := findComposeCandidates(base)
+	assert.Equal(t, []string{"good"}, got)
+}
+
+func TestExtractDeclaredState_MissingComposeDir_WithSibling_NamesCandidate(t *testing.T) {
+	// The configured dir has no compose/, but a sibling child does — the
+	// GH#214 InfraSubDir="." shape. The error must still be ErrComposeDirMissing
+	// but name the candidate so the operator knows what to set BOSUN_INFRA_DIR to.
+	dir := t.TempDir()
+	mkdirs(t, dir, "unraid/compose")
+
+	declared, err := ExtractDeclaredState(dir)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrComposeDirMissing)
+	assert.Contains(t, err.Error(), "unraid")
+	assert.Empty(t, declared)
+}
+
 func TestExtractDeclaredState_DeduplicatesServices(t *testing.T) {
 	dir := t.TempDir()
 	composeDir := filepath.Join(dir, "compose")

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1060,9 +1060,13 @@ func suggestInfraDir(infraSubDir string, candidates []string) string {
 		vals[i] = filepath.Join(infraSubDir, c)
 	}
 	if len(vals) == 1 {
-		return fmt.Sprintf("did you mean BOSUN_INFRA_DIR=%s?", vals[0])
+		return fmt.Sprintf("did you mean BOSUN_INFRA_DIR=%q?", vals[0])
 	}
-	return fmt.Sprintf("set BOSUN_INFRA_DIR to one of: %s", strings.Join(vals, ", "))
+	quoted := make([]string, len(vals))
+	for i, v := range vals {
+		quoted[i] = fmt.Sprintf("%q", v)
+	}
+	return fmt.Sprintf("set BOSUN_INFRA_DIR to one of: %s", strings.Join(quoted, ", "))
 }
 
 // renderTemplates renders all templates to the staging directory.

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/trace"
@@ -531,6 +532,9 @@ func (r *Reconciler) Run(ctx context.Context) (runErr error) {
 	switch {
 	case errors.Is(err, ErrComposeDirMissing):
 		r.sendThrottledFailureAlert(ctx, state, "staging compose directory missing")
+		if hint := suggestInfraDir(r.config.InfraSubDir, findComposeCandidates(stagingSubDir)); hint != "" {
+			return fmt.Errorf("declared-state invariant: %w — %s", err, hint)
+		}
 		return fmt.Errorf("declared-state invariant: %w", err)
 	case errors.Is(err, ErrNoDeclaredServices):
 		if !r.config.AllowEmptyDeclaredState {
@@ -1040,6 +1044,25 @@ func MergeTargetSecrets(secrets map[string]any, scope string) map[string]any {
 	}
 
 	return merged
+}
+
+// suggestInfraDir formats an operator hint naming the BOSUN_INFRA_DIR value(s)
+// that would point at a discovered infra root, given the current InfraSubDir and
+// candidate sibling directory names (from findComposeCandidates). Each candidate
+// is joined with InfraSubDir so the suggestion is the value to set, not just the
+// sibling name. Returns "" when there are no candidates. See GH#214.
+func suggestInfraDir(infraSubDir string, candidates []string) string {
+	if len(candidates) == 0 {
+		return ""
+	}
+	vals := make([]string, len(candidates))
+	for i, c := range candidates {
+		vals[i] = filepath.Join(infraSubDir, c)
+	}
+	if len(vals) == 1 {
+		return fmt.Sprintf("did you mean BOSUN_INFRA_DIR=%s?", vals[0])
+	}
+	return fmt.Sprintf("set BOSUN_INFRA_DIR to one of: %s", strings.Join(vals, ", "))
 }
 
 // renderTemplates renders all templates to the staging directory.

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -39,9 +39,9 @@ func TestSuggestInfraDir(t *testing.T) {
 		want        string
 	}{
 		{"no candidates", ".", nil, ""},
-		{"single candidate at root", ".", []string{"unraid"}, "did you mean BOSUN_INFRA_DIR=unraid?"},
-		{"single candidate nested", "foo", []string{"bar"}, "did you mean BOSUN_INFRA_DIR=foo/bar?"},
-		{"multiple candidates", ".", []string{"staging", "unraid"}, "set BOSUN_INFRA_DIR to one of: staging, unraid"},
+		{"single candidate at root", ".", []string{"unraid"}, `did you mean BOSUN_INFRA_DIR="unraid"?`},
+		{"single candidate nested", "foo", []string{"bar"}, `did you mean BOSUN_INFRA_DIR="foo/bar"?`},
+		{"multiple candidates", ".", []string{"staging", "unraid"}, `set BOSUN_INFRA_DIR to one of: "staging", "unraid"`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -31,6 +31,25 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 5, cfg.BackupsToKeep)
 }
 
+func TestSuggestInfraDir(t *testing.T) {
+	tests := []struct {
+		name        string
+		infraSubDir string
+		candidates  []string
+		want        string
+	}{
+		{"no candidates", ".", nil, ""},
+		{"single candidate at root", ".", []string{"unraid"}, "did you mean BOSUN_INFRA_DIR=unraid?"},
+		{"single candidate nested", "foo", []string{"bar"}, "did you mean BOSUN_INFRA_DIR=foo/bar?"},
+		{"multiple candidates", ".", []string{"staging", "unraid"}, "set BOSUN_INFRA_DIR to one of: staging, unraid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, suggestInfraDir(tt.infraSubDir, tt.candidates))
+		})
+	}
+}
+
 func TestNewReconciler(t *testing.T) {
 	cfg := &Config{
 		RepoURL:    "https://github.com/test/repo.git",

--- a/openspec/changes/add-infra-dir-misconfig-hint/design.md
+++ b/openspec/changes/add-infra-dir-misconfig-hint/design.md
@@ -1,0 +1,77 @@
+# Design: Infra Directory Misconfiguration Hint
+
+## Context
+
+`ExtractDeclaredState(stagingDir)` (`internal/reconcile/drift.go`) stats
+`filepath.Join(stagingDir, "compose")` and returns `ErrComposeDirMissing` when
+it does not exist. `stagingDir` here is `StagingDir/InfraSubDir` — the rendered
+mirror of the repo's infra directory. The function does not know `InfraSubDir`
+itself; it only receives the already-joined path.
+
+The diagnostic value we want — "did you mean `BOSUN_INFRA_DIR=unraid`?" — needs
+two pieces of information that live in different places:
+
+1. **Which sibling contains `compose/`** — discoverable by scanning the children
+   of `stagingDir`. `ExtractDeclaredState` has `stagingDir`, so it can scan.
+2. **The `BOSUN_INFRA_DIR` value to suggest** — `filepath.Join(InfraSubDir,
+   candidate)`. Only the stage-6 call site in `reconcile.go` knows the current
+   `InfraSubDir`.
+
+## Decision
+
+**Split the responsibility along the information boundary.**
+
+- A small helper in `drift.go` — `findComposeCandidates(dir string) []string` —
+  reads the immediate children of `dir` and returns the names of those that
+  contain a `compose/` subdirectory. Pure modulo filesystem; trivially testable.
+- `ExtractDeclaredState` calls the helper when `composeDir` is absent and wraps
+  the candidate names into the `ErrComposeDirMissing` error message (relative to
+  the infra dir — e.g. `unraid`). This keeps the function self-contained and its
+  error useful even for callers that don't post-process it.
+- The stage-6 call site in `reconcile.go` — which holds `InfraSubDir` — is
+  responsible for the fully-qualified suggestion (`BOSUN_INFRA_DIR=<join>`) when
+  it surfaces/logs the error. The base error names the candidate; the call site
+  upgrades it to a copy-pasteable env assignment.
+
+### Why scan in `ExtractDeclaredState` rather than only at the call site
+
+The error originates in `drift.go`. Tests for `ExtractDeclaredState` already
+assert on the error; adding the candidate name there keeps the contract local
+and the unit test simple (no need to stand up a `Reconciler`). The call site
+adds the `InfraSubDir` prefix for the operator-facing form but does not need to
+re-scan.
+
+### Suggestion format
+
+- **Zero candidates** (`compose/` truly absent everywhere): keep the existing
+  bare `ErrComposeDirMissing: <path>` message. No misleading suggestion.
+- **One candidate** (`unraid`): `... did you mean BOSUN_INFRA_DIR=unraid?`
+- **Multiple candidates** (`unraid`, `staging`): list them —
+  `... candidate infra dirs with compose/: [unraid staging]; set BOSUN_INFRA_DIR
+  to one of them`.
+
+## Edge Cases
+
+| Case | Behavior |
+|---|---|
+| `stagingDir` itself unreadable | Existing `os.Stat`/`ReadDir` error path; no scan. Don't mask I/O errors with a hint. |
+| Candidate dir has `compose/` but it's a file, not a dir | Not a candidate — require `compose/` to be a directory (matches what `ExtractDeclaredState` would glob). |
+| Nested deeper than one level (`a/b/compose`) | Out of scope. One-level scan covers the overwhelming common case (the GH#214 shape). A deeper scan risks O(tree) cost on a failing path and ambiguous suggestions. |
+| Hidden dirs (`.beads`, `.git`) contain `compose/` | Skip dot-prefixed children — they are never legitimate infra roots and would produce noisy suggestions. |
+| Current `InfraSubDir="."`, candidate `unraid` | Suggested value is `unraid` (`filepath.Join(".", "unraid")` → `unraid`). |
+| Current `InfraSubDir="foo"`, candidate `bar` | Suggested value is `foo/bar`. |
+
+## Performance
+
+The scan runs only on the already-failing `ErrComposeDirMissing` path — never on
+the happy path. It reads one directory level and stats one subdirectory per
+child. Cost is O(children of infra dir), bounded and off the hot path.
+
+## Testing Strategy
+
+- `findComposeCandidates` unit tests: zero / one / multiple candidates, dot-dir
+  exclusion, `compose`-is-a-file rejection, unreadable dir.
+- `ExtractDeclaredState` test: missing `compose/` with a sibling holding
+  `compose/` → error names the candidate.
+- Call-site test (or table extension): the surfaced error contains
+  `BOSUN_INFRA_DIR=<join>` for representative `InfraSubDir` values.

--- a/openspec/changes/add-infra-dir-misconfig-hint/proposal.md
+++ b/openspec/changes/add-infra-dir-misconfig-hint/proposal.md
@@ -1,0 +1,64 @@
+# Change: Suggest the correct BOSUN_INFRA_DIR when the compose directory is missing
+
+## Why
+
+GitHub #214's root cause was confirmed on 2026-05-19: the silent-success deploy
+was caused by `BOSUN_INFRA_DIR="."` while the homelab's infrastructure
+(`compose/` and `appdata/`) is nested under `unraid/`. With `InfraSubDir="."`
+the entire repo became the infra root, so `ExtractDeclaredState` globbed a
+non-existent `staging/compose`, `discoverDeployTargets` treated repo-metadata
+dirs (`.beads`, `.claude`, `unraid`) as deploy targets, and the sync mapped
+`staging/unraid → /mnt/appdata/unraid` — landing rendered output at a path
+nothing reads.
+
+The `add-deploy-sync-invariants` change (Layer 1) already converts this into a
+loud failure: `ExtractDeclaredState` now returns `ErrComposeDirMissing` and the
+reconcile aborts. But the error only names the *missing* path
+(`<staging>/compose`); it does not tell the operator what to set instead. The
+operator's own config comment — `# . = repo root, templates in unraid/` —
+shows the mental-model gap that produced the misconfiguration: they expected
+Bosun to "find templates under unraid/" when `InfraSubDir` *is* the infra root.
+
+Bosun already has enough on disk to diagnose this precisely. When the configured
+compose directory is missing, a sibling directory almost always contains the
+real `compose/`. Naming it turns a dead-end error ("compose dir missing") into a
+one-line fix ("did you mean `BOSUN_INFRA_DIR=unraid`?").
+
+## What Changes
+
+- **Missing-compose-dir errors gain a diagnostic hint.** When the configured
+  infra/staging directory has no `compose/` child, the reconciler SHALL scan the
+  directory's immediate children for any that themselves contain a `compose/`
+  subdirectory. When one or more candidates are found, the failure SHALL name
+  them and suggest the `BOSUN_INFRA_DIR` value that would point at the infra
+  root.
+- **The hint is diagnostic only.** It does NOT auto-correct `InfraSubDir` or
+  change any deploy behavior. `ErrComposeDirMissing` still fails the reconcile
+  unconditionally (per the existing Deploy Sync Invariants requirement). The
+  hint only enriches the error message and log.
+- **No new configuration surface.** No new env vars, no new config fields. The
+  scan is bounded (one level of children, checking for a single subdirectory)
+  so it adds negligible latency to an already-failing path.
+
+## Impact
+
+- **Affected specs:** reconcile (added — Infra Directory Misconfiguration Hint)
+- **Affected code:**
+  - `internal/reconcile/drift.go` — `ExtractDeclaredState` (or a sibling helper)
+    scans for candidate infra dirs when `composeDir` is absent; returns the
+    candidates alongside `ErrComposeDirMissing`.
+  - `internal/reconcile/reconcile.go` — the stage-6 call site, which knows the
+    current `InfraSubDir`, composes the suggested `BOSUN_INFRA_DIR` value
+    (`filepath.Join(currentInfraSubDir, candidate)`) into the surfaced error.
+- **Operator-visible change:** a reconcile that previously failed with
+  `compose dir missing: /app/staging/compose` now fails with an actionable
+  message naming the candidate and the env var to set.
+- **CHANGELOG:** patch-level improvement to error messaging; not a behavior or
+  contract change (the failure still happens; only the message improves).
+- **Out of scope:**
+  - Auto-correcting or inferring `InfraSubDir` at runtime — surfacing a
+    suggestion is safe; silently changing where Bosun deploys is not.
+  - The homelab config fix itself (`BOSUN_INFRA_DIR=unraid` + hook globs) — that
+    lives in the `cameronsjo/homelab` repo, not Bosun.
+  - A `bosun doctor` mirror of this check — a reasonable follow-up, but the
+    reconcile-time error is where operators actually hit the failure.

--- a/openspec/changes/add-infra-dir-misconfig-hint/specs/reconcile/spec.md
+++ b/openspec/changes/add-infra-dir-misconfig-hint/specs/reconcile/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Infra Directory Misconfiguration Hint
+
+The reconciler SHALL diagnose a likely `BOSUN_INFRA_DIR` misconfiguration when the configured infra/staging directory has no `compose/` child (the condition that produces `ErrComposeDirMissing`), before surfacing the failure.
+
+To do so, the reconciler SHALL scan the immediate child directories of the
+infra/staging directory and identify any whose own contents include a
+`compose/` subdirectory. Dot-prefixed children (e.g. `.beads`, `.git`) SHALL be excluded,
+and a `compose` entry that is a file rather than a directory SHALL NOT count as
+a candidate.
+
+- When one or more candidates are found, the surfaced `ErrComposeDirMissing`
+  failure SHALL name them and SHALL include a suggested `BOSUN_INFRA_DIR` value
+  formed by joining the current `InfraSubDir` with the candidate name.
+- When no candidate is found, the failure SHALL retain its existing bare message
+  naming the missing compose directory path, with no suggestion.
+
+The hint SHALL be diagnostic only. It SHALL NOT auto-correct `InfraSubDir`,
+SHALL NOT change which paths are deployed, and SHALL NOT alter the unconditional
+failure semantics of `ErrComposeDirMissing` defined by the Deploy Sync
+Invariants requirement. The scan SHALL run only on the failing path (compose
+directory absent), never on a successful reconcile.
+
+#### Scenario: Single candidate names the infra dir to set
+
+- **WHEN** `ExtractDeclaredState` finds no `compose/` under the configured infra dir
+- **AND** exactly one child directory (e.g. `unraid`) contains a `compose/` subdirectory
+- **THEN** the reconcile fails with `ErrComposeDirMissing`
+- **AND** the error names `unraid` as the candidate infra directory
+- **AND** the surfaced error includes a suggested `BOSUN_INFRA_DIR` value formed from the current `InfraSubDir` joined with `unraid`
+
+#### Scenario: Multiple candidates are all listed
+
+- **WHEN** `ExtractDeclaredState` finds no `compose/` under the configured infra dir
+- **AND** more than one child directory contains a `compose/` subdirectory
+- **THEN** the error lists every candidate directory
+- **AND** directs the operator to set `BOSUN_INFRA_DIR` to one of them
+
+#### Scenario: No candidate keeps the bare error
+
+- **WHEN** `ExtractDeclaredState` finds no `compose/` under the configured infra dir
+- **AND** no child directory contains a `compose/` subdirectory
+- **THEN** the reconcile fails with `ErrComposeDirMissing` naming the missing path
+- **AND** no `BOSUN_INFRA_DIR` suggestion is appended
+
+#### Scenario: Dot-directories and compose files are not candidates
+
+- **WHEN** scanning for candidate infra directories
+- **AND** a child is dot-prefixed (e.g. `.beads`) or its `compose` entry is a file
+- **THEN** that child is not offered as a candidate
+
+#### Scenario: Hint does not change failure semantics
+
+- **WHEN** a candidate infra directory is identified
+- **THEN** the reconcile still fails unconditionally on `ErrComposeDirMissing`
+- **AND** `BOSUN_ALLOW_EMPTY_DECLARED_STATE` does not suppress the failure
+- **AND** no deploy or `InfraSubDir` value is changed automatically

--- a/openspec/changes/add-infra-dir-misconfig-hint/tasks.md
+++ b/openspec/changes/add-infra-dir-misconfig-hint/tasks.md
@@ -1,4 +1,4 @@
-# Tasks: Infra Directory Misconfiguration Hint
+## Tasks: Infra Directory Misconfiguration Hint
 
 ## 1. Candidate scanning helper
 

--- a/openspec/changes/add-infra-dir-misconfig-hint/tasks.md
+++ b/openspec/changes/add-infra-dir-misconfig-hint/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Infra Directory Misconfiguration Hint
+
+## 1. Candidate scanning helper
+
+- [ ] `internal/reconcile/drift.go` — add `findComposeCandidates(dir string) []string`: read immediate children, return names of directories containing a `compose/` subdirectory; exclude dot-prefixed children; reject `compose` entries that are files
+- [ ] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_SingleCandidate`
+- [ ] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_MultipleCandidates`
+- [ ] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_NoCandidate_Empty`
+- [ ] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_SkipsDotDirsAndComposeFile`
+
+## 2. Wire the hint into ExtractDeclaredState
+
+- [ ] `internal/reconcile/drift.go` — when `composeDir` is absent, call `findComposeCandidates(stagingDir)` and include candidate names in the `ErrComposeDirMissing` message (relative to the infra dir); keep the bare message when none found
+- [ ] `internal/reconcile/drift_test.go` — `TestExtractDeclaredState_MissingComposeDir_WithSibling_NamesCandidate`
+- [ ] `internal/reconcile/drift_test.go` — `TestExtractDeclaredState_MissingComposeDir_NoSibling_BareError` (regression: existing message preserved)
+
+## 3. Compose the BOSUN_INFRA_DIR suggestion at the call site
+
+- [ ] `internal/reconcile/reconcile.go` — at the stage-6 `ExtractDeclaredState` call site, when the error is `ErrComposeDirMissing` and candidates exist, surface a suggested `BOSUN_INFRA_DIR=<filepath.Join(InfraSubDir, candidate)>` in the wrapped error and log
+- [ ] `internal/reconcile/reconcile_test.go` (or drift integration test) — assert the surfaced error contains `BOSUN_INFRA_DIR=unraid` for `InfraSubDir="."` + candidate `unraid`
+- [ ] confirm `BOSUN_ALLOW_EMPTY_DECLARED_STATE` does not suppress the failure (sentinel is still `ErrComposeDirMissing`)
+
+## 4. Documentation
+
+- [ ] `docs/troubleshooting.md` — extend the "Deploy reports success but files unchanged" / compose-dir-missing section with the new suggestion behavior and an example
+- [ ] `skills/onboard/resources/gitops.md` — note that a missing compose dir now suggests the correct `BOSUN_INFRA_DIR`
+- [ ] `docs/error-handling.md` — update the `ErrComposeDirMissing` entry to mention the candidate hint (if the sentinel is documented there)
+
+## 5. Verification
+
+- [ ] `go test ./internal/reconcile/` passes
+- [ ] `make build` succeeds
+- [ ] `openspec validate add-infra-dir-misconfig-hint --strict` passes
+- [ ] Manual: point `BOSUN_INFRA_DIR=.` at a repo whose infra is under `unraid/`, run reconcile, confirm the error names `unraid` and suggests `BOSUN_INFRA_DIR=unraid`

--- a/openspec/changes/add-infra-dir-misconfig-hint/tasks.md
+++ b/openspec/changes/add-infra-dir-misconfig-hint/tasks.md
@@ -2,33 +2,33 @@
 
 ## 1. Candidate scanning helper
 
-- [ ] `internal/reconcile/drift.go` — add `findComposeCandidates(dir string) []string`: read immediate children, return names of directories containing a `compose/` subdirectory; exclude dot-prefixed children; reject `compose` entries that are files
-- [ ] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_SingleCandidate`
-- [ ] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_MultipleCandidates`
-- [ ] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_NoCandidate_Empty`
-- [ ] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_SkipsDotDirsAndComposeFile`
+- [x] `internal/reconcile/drift.go` — add `findComposeCandidates(dir string) []string`: read immediate children, return names of directories containing a `compose/` subdirectory; exclude dot-prefixed children; reject `compose` entries that are files
+- [x] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_SingleCandidate`
+- [x] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_MultipleCandidates`
+- [x] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_NoCandidate_Empty`
+- [x] `internal/reconcile/drift_test.go` — `TestFindComposeCandidates_SkipsDotDirsAndComposeFile`
 
 ## 2. Wire the hint into ExtractDeclaredState
 
-- [ ] `internal/reconcile/drift.go` — when `composeDir` is absent, call `findComposeCandidates(stagingDir)` and include candidate names in the `ErrComposeDirMissing` message (relative to the infra dir); keep the bare message when none found
-- [ ] `internal/reconcile/drift_test.go` — `TestExtractDeclaredState_MissingComposeDir_WithSibling_NamesCandidate`
-- [ ] `internal/reconcile/drift_test.go` — `TestExtractDeclaredState_MissingComposeDir_NoSibling_BareError` (regression: existing message preserved)
+- [x] `internal/reconcile/drift.go` — when `composeDir` is absent, call `findComposeCandidates(stagingDir)` and include candidate names in the `ErrComposeDirMissing` message; keep the bare message when none found
+- [x] `internal/reconcile/drift_test.go` — `TestExtractDeclaredState_MissingComposeDir_WithSibling_NamesCandidate`
+- [x] No-sibling bare-error regression covered by existing `TestExtractDeclaredState_NoComposeDir` (empty dir → no candidates → bare `ErrComposeDirMissing`)
 
 ## 3. Compose the BOSUN_INFRA_DIR suggestion at the call site
 
-- [ ] `internal/reconcile/reconcile.go` — at the stage-6 `ExtractDeclaredState` call site, when the error is `ErrComposeDirMissing` and candidates exist, surface a suggested `BOSUN_INFRA_DIR=<filepath.Join(InfraSubDir, candidate)>` in the wrapped error and log
-- [ ] `internal/reconcile/reconcile_test.go` (or drift integration test) — assert the surfaced error contains `BOSUN_INFRA_DIR=unraid` for `InfraSubDir="."` + candidate `unraid`
-- [ ] confirm `BOSUN_ALLOW_EMPTY_DECLARED_STATE` does not suppress the failure (sentinel is still `ErrComposeDirMissing`)
+- [x] `internal/reconcile/reconcile.go` — add `suggestInfraDir(infraSubDir, candidates)` (joins each candidate with `InfraSubDir`); at the stage-6 `ErrComposeDirMissing` case, append the suggestion to the surfaced error
+- [x] `internal/reconcile/reconcile_test.go` — `TestSuggestInfraDir` (table: none / single-root / single-nested / multiple)
+- [x] Failure still keyed on `ErrComposeDirMissing`; `BOSUN_ALLOW_EMPTY_DECLARED_STATE` does not suppress it (unchanged sentinel + switch arm)
 
 ## 4. Documentation
 
-- [ ] `docs/troubleshooting.md` — extend the "Deploy reports success but files unchanged" / compose-dir-missing section with the new suggestion behavior and an example
-- [ ] `skills/onboard/resources/gitops.md` — note that a missing compose dir now suggests the correct `BOSUN_INFRA_DIR`
-- [ ] `docs/error-handling.md` — update the `ErrComposeDirMissing` entry to mention the candidate hint (if the sentinel is documented there)
+- [x] `docs/troubleshooting.md` — extend the "Deploy reports success but files unchanged" section with the suggestion behavior and an example
+- [x] `skills/onboard/resources/gitops.md` — note that a missing compose dir now suggests the correct `BOSUN_INFRA_DIR`
+- [x] `docs/error-handling.md` — update the `ErrComposeDirMissing` entry to mention the candidate hint
 
 ## 5. Verification
 
-- [ ] `go test ./internal/reconcile/` passes
-- [ ] `make build` succeeds
-- [ ] `openspec validate add-infra-dir-misconfig-hint --strict` passes
-- [ ] Manual: point `BOSUN_INFRA_DIR=.` at a repo whose infra is under `unraid/`, run reconcile, confirm the error names `unraid` and suggests `BOSUN_INFRA_DIR=unraid`
+- [x] `go test ./internal/reconcile/` passes
+- [x] `make build` succeeds
+- [x] `openspec validate add-infra-dir-misconfig-hint --strict` passes
+- [ ] Manual: point `BOSUN_INFRA_DIR=.` at a repo whose infra is under `unraid/`, run reconcile, confirm the error names `unraid` and suggests `BOSUN_INFRA_DIR=unraid` (post-merge / homelab validation)

--- a/skills/onboard/resources/gitops.md
+++ b/skills/onboard/resources/gitops.md
@@ -58,7 +58,7 @@ Every reconciliation follows this 16-stage sequence:
 
 Bosun enforces two invariant gates that turn the GH#214 silent-success failure mode into a loud error:
 
-- **Declared-state invariant (stage 6)** — if `ExtractDeclaredState` returns `ErrComposeDirMissing` the reconcile fails unconditionally (no override). If it returns `ErrNoDeclaredServices` the reconcile fails unless `BOSUN_ALLOW_EMPTY_DECLARED_STATE=true` is set; the override logs at `Warn` level with `override=true`.
+- **Declared-state invariant (stage 6)** — if `ExtractDeclaredState` returns `ErrComposeDirMissing` the reconcile fails unconditionally (no override). When the infra dir has no `compose/` but a sibling directory does, the error names the candidate and suggests the `BOSUN_INFRA_DIR` value to set (e.g. `did you mean BOSUN_INFRA_DIR=unraid?`) — the GH#214 misconfiguration. If it returns `ErrNoDeclaredServices` the reconcile fails unless `BOSUN_ALLOW_EMPTY_DECLARED_STATE=true` is set; the override logs at `Warn` level with `override=true`.
 - **Post-deploy invariant (stage 9)** — for every file in `DeployResult.WrittenFiles`, the destination must exist at `mtime >= reconcileStartTime`. If a deploy target's source staging dir contains regular files but the target's `WrittenFiles` is empty, that is the GH#214 silent-sync signature and fails the reconcile before `docker compose up` runs.
 
 Operators can bypass the post-deploy invariant for diagnostic deploys via `BOSUN_SKIP_DEPLOY_INVARIANT=true`. The skip is logged at `Warn` level with `override=true` so it shows up in monitoring; the declared-state invariant is not affected by this flag.


### PR DESCRIPTION
## Summary

Layer 3 of the GH#214 work: make a `BOSUN_INFRA_DIR` misconfiguration **self-diagnosing** instead of a bare "compose directory missing" error.

When the staging compose dir is absent, the reconciler now scans sibling directories for a `compose/` subdir and, if it finds candidates, names them in the error and suggests the corrected `BOSUN_INFRA_DIR` value.

This is the root cause of #214: infra (`compose/`, `appdata/`) lived under `unraid/` while `BOSUN_INFRA_DIR` was `"."`, so render/discover/deploy all faithfully resolved to the repo root and silently deployed nothing useful.

## Changes

- `internal/reconcile/drift.go` — `findComposeCandidates(dir)` scans for sibling dirs containing `compose/`; `ExtractDeclaredState` names them in the `ErrComposeDirMissing` error.
- `internal/reconcile/reconcile.go` — `suggestInfraDir()` turns candidates into an actionable hint (`did you mean BOSUN_INFRA_DIR=unraid?`), wired into the stage-6 missing-compose-dir failure path.
- Tests: `TestFindComposeCandidates_*` (4), `TestExtractDeclaredState_MissingComposeDir_WithSibling_NamesCandidate`, table-driven `TestSuggestInfraDir`.
- OpenSpec proposal `add-infra-dir-misconfig-hint` (validates `--strict`).
- Docs: troubleshooting, error-handling, onboard/gitops skill resource.

## Verification

- `go vet ./internal/reconcile/...`, `go build ./...` — clean
- `go test ./internal/reconcile/ -count=1` — pass (fresh)
- `openspec validate add-infra-dir-misconfig-hint --strict` — valid

Refs GH#214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
