### PR TITLE
spec: add-rollback-health-semantics — restore-not-rerun rollback + bounded health polling (Cluster E)

### DIFF
--- a/openspec/changes/add-rollback-health-semantics/design.md
+++ b/openspec/changes/add-rollback-health-semantics/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Cluster E of the April 2026 reconcile-path bug hunt covers two P0 findings in
+the post-deploy safety path. Both failures share a root pattern: a guard appears
+to run but does nothing useful in its failure mode.
+
+- #229: the health-gate "rollback" reuses `ComposeUpMultipleWithRollback`, which
+  is a *deploy-or-rollback* helper. It runs `docker compose up` against the
+  caller-supplied compose files first and only falls back to the backup if that
+  fails. The health-gate caller supplies the **new** (failing) files, so the
+  initial `up` exits 0 (containers exist, just unhealthy) and the backup is never
+  consulted.
+- #230: `pollContainerHealth` keeps its deadline check inside the success branch
+  of `CollectActualState`, and its select has no deadline case. A sustained
+  Docker API error therefore loops forever.
+
+The fix is semantic, not cosmetic: "rollback" must mean "restore the prior good
+state," and "poll for health" must be bounded on every exit path. Encoding these
+as spec requirements gives the implementation something to regress against.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Rollback after a failed health gate restores the backed-up prior compose
+    files, not the new render.
+  - Health polling terminates on Docker API errors and at the deadline.
+  - A failed rollback is reported distinctly from a successful one.
+- Non-Goals:
+  - Changing the health-gate classification table (healthy / no-healthcheck /
+    unhealthy / starting / missing) — that stays as specified.
+  - Adding new config or env vars. Existing `HealthCheckTimeout`,
+    `HealthCheckInterval`, `HealthGateTimeout`, and backup paths are sufficient.
+  - Remote-deploy rollback (the health gate is already skipped for remote
+    targets).
+
+## Decisions
+
+- **Decision: separate "restore from backup" from "deploy or rollback."** The
+  health-gate failure path gets a dedicated restore call that deploys
+  `r.lastBackupPath`'s compose files directly, modeled on the existing
+  `ComposeUpIsolated` rollback at `compose.go:~325`. The deploy-failure path
+  keeps using `ComposeUpMultipleWithRollback`.
+  - Alternatives considered: make `ComposeUpMultipleWithRollback` detect the
+    already-running case and force the backup. Rejected — overloading one helper
+    with two opposite intents is exactly what produced the bug.
+
+- **Decision: deadline check runs unconditionally each iteration; select carries
+  a deadline case.** A persistent `CollectActualState` error yields a failed
+  `HealthCheckResult` at the deadline rather than an infinite loop.
+  - Alternatives considered: bail on the first Docker API error. Rejected — a
+    transient blip should not fail an otherwise healthy deploy; the timeout is
+    the correct bound. The distinction is *unhealthy* (keep polling) vs *cannot
+    query* (bounded by deadline, then fail).
+
+- **Decision: preserve the `ErrRollbackSucceeded` / `ErrRollbackFailed` sentinel
+  contract.** Service Orchestration already defines these sentinels for the
+  deploy-failure rollback. The health-gate restore path reuses them so callers
+  and logs stay consistent, and a failed restore is logged at ERROR as a
+  critical state.
+
+## Risks / Trade-offs
+
+- A backup that is itself broken means restore cannot recover → surfaced as
+  `ErrRollbackFailed` (critical state), which is the honest outcome rather than a
+  false success.
+- Treating sustained Docker API errors as a deadline-bounded failure could mask a
+  genuinely slow-but-recovering daemon → mitigated because the bound is the
+  configured `HealthCheckTimeout`, the same window operators already tune.
+
+## Migration Plan
+
+No config migration. Behavior change is strictly safer: rollback that previously
+silently no-op'd now restores the backup; health polling that previously hung now
+terminates. No state-file schema change.
+
+## Open Questions
+
+- None blocking. Whether the restore path should also re-run post-restore health
+  verification is left to implementation; the spec requires only that the prior
+  good files are redeployed and the outcome is surfaced via the sentinels.

--- a/openspec/changes/add-rollback-health-semantics/proposal.md
+++ b/openspec/changes/add-rollback-health-semantics/proposal.md
@@ -1,0 +1,70 @@
+# Change: Restore-not-rerun rollback and bounded post-deploy health polling
+
+## Why
+
+The April 2026 reconcile-path bug hunt (Cluster E) found that the two safety
+mechanisms guarding bad deploys are fictional in their failure modes.
+
+When the critical-container health gate fails, the reconciler calls
+`ComposeUpMultipleWithRollback(ctx, r.lastComposeFiles, r.lastBackupPath)`. But
+`r.lastComposeFiles` is the **new, just-deployed, now-failing** file set, and
+that helper first runs `docker compose up` against those same files. Because the
+containers already exist and are merely unhealthy, compose exits 0, the helper
+returns nil without ever touching the backup, and the reconciler logs "rollback
+attempted" while Docker keeps running the broken release (#229, P0). Rollback is
+silently a no-op — the documented "don't ship broken services" guarantee does
+not hold.
+
+Separately, post-deploy health polling (`pollContainerHealth`) places its
+deadline check inside the success branch of its state-collection call. When the
+Docker API errors for the whole health window (daemon restart, socket
+permission, network blip), the deadline is never consulted and the select has no
+deadline case, so the function polls forever — wedging health verification, the
+state save, and the circuit breaker (#230, P0).
+
+Neither behavior is pinned by an authoritative requirement, so there is nothing
+to regress against. This proposal adds reconcile requirements that fix the
+semantics: rollback restores the prior good state rather than re-applying the
+broken render, health polling terminates on Docker API errors and at the
+deadline, and a failed rollback is surfaced distinctly rather than swallowed.
+
+## What Changes
+
+- **Rollback restores prior good state** — when the post-deploy health gate
+  fails, rollback SHALL re-deploy the backed-up prior compose files (a distinct
+  "restore from backup" path), NOT re-run `docker compose up` against the new
+  rendered output. Rollback ≠ "deploy again."
+- **Bounded health polling** — post-deploy health verification polling SHALL
+  evaluate its deadline every iteration regardless of Docker API success, SHALL
+  carry a deadline/timeout case in its wait loop, and SHALL terminate with a
+  failed result on persistent Docker API errors. It MUST distinguish "container
+  unhealthy" (keep polling within the timeout) from "cannot query health"
+  (bounded — fail at the deadline).
+- **Rollback failure is surfaced distinctly** — a failed rollback after a failed
+  health gate SHALL be reported as a critical state distinct from a successful
+  rollback (preserving the `ErrRollbackSucceeded` / `ErrRollbackFailed` sentinel
+  contract), and SHALL NOT be swallowed or logged as a generic success.
+
+## Impact
+
+- Affected specs: `reconcile` (ADDED requirements only; no existing requirement
+  changes semantics, so `Service Orchestration`, `Critical Container Health
+  Gate`, and `Post-Deploy Verification` are left intact).
+- Affected code:
+  - `internal/reconcile/reconcile.go:872-877` — health-gate failure path that
+    calls `ComposeUpMultipleWithRollback(ctx, r.lastComposeFiles, ...)`
+  - `internal/reconcile/compose.go:172-192` — `ComposeUpMultipleWithRollback`
+    (deploy-or-rollback) reused incorrectly for the already-deployed-unhealthy
+    case; line 180 `upFn(ctx, composeFiles)` re-runs the new files
+  - `internal/reconcile/compose.go:~325` — `ComposeUpIsolated` rollback path,
+    the existing "explicitly redeploy backup" pattern the gate path should reuse
+  - `internal/reconcile/health.go:41-92` — `pollContainerHealth` deadline check
+    trapped in the `else` branch; select lacks a deadline case
+- All consumers of the rollback / health-gate surface (each needs a scenario):
+  - Critical-container health-gate failure path (`reconcile.go`) — triggers the
+    rollback
+  - `ComposeUpMultipleWithRollback` (`compose.go`) — the deploy-failure rollback
+    path that returns the sentinels
+  - `pollContainerHealth` / post-deploy verification (`health.go`) — the polling
+    loop bounded by `HealthCheckTimeout` / `HealthCheckInterval`
+- Docs: `skills/onboard/resources/gitops.md` (rollback + health-gate semantics).

--- a/openspec/changes/add-rollback-health-semantics/specs/reconcile/spec.md
+++ b/openspec/changes/add-rollback-health-semantics/specs/reconcile/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Health-Gate Rollback Restores Prior State
+
+When the critical-container health gate fails, the reconciler SHALL restore the backed-up prior compose configuration by re-deploying the backup compose files, and SHALL NOT re-run `docker compose up` against the new (just-deployed, now-unhealthy) rendered output.
+
+The health-gate rollback path SHALL be distinct from the deploy-failure rollback helper (`ComposeUpMultipleWithRollback`). The deploy-failure helper runs the caller-supplied compose files first and only falls back to the backup on error; reusing it for the health-gate case is incorrect because the already-running-but-unhealthy containers cause the initial `up` to exit 0, so the backup is never consulted. The health-gate path SHALL instead deploy the backup files directly (the "restore from backup" pattern used by `ComposeUpIsolated`).
+
+The restore SHALL operate on the recorded backup path (`r.lastBackupPath`), not on `r.lastComposeFiles` (the new render). The restore SHALL NOT short-circuit on the basis that the new containers already exist and are merely reporting unhealthy.
+
+#### Scenario: Health-gate failure redeploys backup files
+
+- **WHEN** a critical container is unhealthy after the health gate timeout
+- **AND** a backup exists at `r.lastBackupPath` with the previous-good compose files
+- **THEN** the reconciler re-deploys the backup compose files
+- **AND** does NOT re-run compose up against the new rendered output (`r.lastComposeFiles`)
+- **AND** the deployment is NOT recorded as successful
+
+#### Scenario: Already-running unhealthy containers do not short-circuit rollback
+
+- **WHEN** the new containers already exist and report "unhealthy"
+- **THEN** rollback still re-deploys the backup files
+- **AND** does not treat the existing-but-unhealthy containers as a successful no-op
+
+### Requirement: Bounded Post-Deploy Health Polling
+
+Post-deploy health verification polling SHALL terminate at the configured timeout and on context cancellation regardless of whether the Docker API call succeeds, and SHALL NOT loop indefinitely when the Docker API returns errors.
+
+The polling loop SHALL evaluate its deadline on every iteration, not only when the underlying state-collection call (`CollectActualState`) succeeds. The wait loop SHALL carry a deadline/timeout case in addition to the context-cancellation and interval-tick cases.
+
+The reconciler SHALL distinguish "container unhealthy" from "cannot query health". A container reporting unhealthy SHALL keep being polled until the timeout elapses. A Docker API error (daemon restart, socket permission, network blip) SHALL be bounded by the same timeout: polling SHALL continue across transient errors but SHALL return a failed `HealthCheckResult` once the deadline is reached, rather than blocking forever.
+
+The bound SHALL be the configured health verification timeout (`HealthCheckTimeout`, default 60 seconds), with the configured poll interval (`HealthCheckInterval`, default 5 seconds).
+
+#### Scenario: Persistent Docker API errors terminate at the deadline
+
+- **WHEN** `CollectActualState` returns an error on every poll iteration for the entire `HealthCheckTimeout` window
+- **THEN** polling logs a warning per failed query
+- **AND** returns a failed `HealthCheckResult` once the deadline is reached
+- **AND** does not loop indefinitely
+
+#### Scenario: Context cancellation stops polling
+
+- **WHEN** the context is cancelled mid-poll
+- **THEN** polling returns promptly without waiting for the next interval tick
+
+#### Scenario: Unhealthy container keeps polling within the timeout
+
+- **WHEN** a container reports "unhealthy" but the deadline has not yet elapsed
+- **THEN** polling continues at the configured interval
+- **AND** returns as soon as the container becomes healthy or the deadline is reached
+
+### Requirement: Rollback Failure Is Surfaced Distinctly
+
+A rollback attempted after a failed health gate SHALL report its outcome distinctly: a successful restore and a failed restore MUST be distinguishable, and a failed rollback MUST NOT be swallowed or logged as a generic deploy success.
+
+The health-gate rollback path SHALL preserve the existing sentinel contract: `ErrRollbackSucceeded` when the backup was restored successfully and `ErrRollbackFailed` when the restore itself failed (critical state). A failed rollback SHALL be logged at ERROR level indicating a critical state. A successful rollback SHALL NOT cause the deployment to be recorded as successful.
+
+#### Scenario: Failed rollback surfaces critical state
+
+- **WHEN** the health gate fails and the backup restore also fails
+- **THEN** the reconciler returns `ErrRollbackFailed`
+- **AND** logs at ERROR level indicating a critical state
+- **AND** the deployment is NOT recorded as successful
+
+#### Scenario: Successful rollback is reported, not masked as success
+
+- **WHEN** the health gate fails and the backup restore succeeds
+- **THEN** the reconciler returns `ErrRollbackSucceeded`
+- **AND** the deployment is NOT recorded as successful
+- **AND** the outcome is not logged as a generic deploy success

--- a/openspec/changes/add-rollback-health-semantics/tasks.md
+++ b/openspec/changes/add-rollback-health-semantics/tasks.md
@@ -1,0 +1,23 @@
+## 1. Rollback restores prior good state (#229)
+
+- [ ] 1.1 Add a distinct "restore from backup" rollback path that redeploys the backed-up prior compose files (mirror the `ComposeUpIsolated` rollback at `compose.go:~325`), instead of reusing `ComposeUpMultipleWithRollback` for the already-deployed-unhealthy case
+- [ ] 1.2 Update the health-gate failure path in `reconcile.go:872-877` to call the restore path with `r.lastBackupPath`, not `ComposeUpMultipleWithRollback(ctx, r.lastComposeFiles, ...)`
+- [ ] 1.3 Ensure the restore path does not short-circuit when containers already exist and merely report unhealthy
+- [ ] 1.4 Tests: critical-container health failure re-deploys the backup compose files (assert the backup file set is used), not the new rendered output
+
+## 2. Bounded post-deploy health polling (#230)
+
+- [ ] 2.1 Move the deadline check in `pollContainerHealth` (`health.go:41-92`) out of the `else` branch so it runs every iteration regardless of `CollectActualState` success
+- [ ] 2.2 Add a deadline/timeout case to the select wait loop (alongside `ctx.Done()` and the interval tick)
+- [ ] 2.3 Distinguish "container unhealthy" (keep polling within the timeout) from "cannot query health" (Docker API error → bounded, fail at deadline) and return a failed `HealthCheckResult` on persistent API errors
+- [ ] 2.4 Tests: `pollContainerHealth` returns a failed result after `HealthCheckTimeout` when `CollectActualState` errors every iteration; also returns on `ctx.Done()`
+
+## 3. Surface rollback failure distinctly (#229)
+
+- [ ] 3.1 Ensure the health-gate rollback path preserves the `ErrRollbackSucceeded` / `ErrRollbackFailed` sentinel contract and logs a failed rollback at ERROR as a critical state
+- [ ] 3.2 Ensure a successful rollback is not logged as a generic deploy success and the deployment is not recorded as successful
+- [ ] 3.3 Tests: failed rollback surfaces `ErrRollbackFailed`; successful rollback surfaces `ErrRollbackSucceeded` and the deploy is not marked successful
+
+## 4. Docs
+
+- [ ] 4.1 Update `skills/onboard/resources/gitops.md` to describe restore-from-backup rollback and bounded health polling


### PR DESCRIPTION
## Summary

Cluster E of the April 2026 reconcile-path bug hunt. Spec-only proposal (no implementation code) correcting two P0 failure-mode bugs in the post-deploy safety path:

- Health-gate "rollback" restores the backed-up prior compose files instead of re-running `docker compose up` against the new (broken) render.
- Post-deploy health polling terminates on Docker API errors and at the deadline instead of looping forever.
- A failed rollback is surfaced distinctly (`ErrRollbackFailed`) rather than swallowed as success.

Adds three ADDED requirements to the `reconcile` capability. No existing requirement semantics change, so `Service Orchestration`, `Critical Container Health Gate`, and `Post-Deploy Verification` are left intact.

## Findings

| # | Sev | Finding |
|---|-----|---------|
| #229 | P0 | health-gate "rollback" silently re-runs the broken deploy instead of restoring the backup |
| #230 | P0 | `pollContainerHealth` infinite loop when the Docker API returns errors |

## Scope

Spec-only / Wave 1. No Go code changes. `openspec validate add-rollback-health-semantics --strict` passes. Implementation is gated on the `ready-to-build` label (not applied here).

Refs bosun-6ba

## Test plan

- [ ] Critical-container health failure re-deploys backup compose files (assert backup file set used, not new render)
- [ ] Already-running-but-unhealthy containers do not short-circuit rollback to a no-op
- [ ] `pollContainerHealth` returns a failed `HealthCheckResult` after `HealthCheckTimeout` when `CollectActualState` errors every iteration
- [ ] `pollContainerHealth` returns promptly on `ctx.Done()`
- [ ] Failed rollback surfaces `ErrRollbackFailed` at ERROR; successful rollback surfaces `ErrRollbackSucceeded` and deploy is not marked successful