### PR TITLE
spec: add-drift-breaker-semantics — bounded self-heal + breaker integrity (Cluster F)

### DIFF
--- a/openspec/changes/add-drift-breaker-semantics/design.md
+++ b/openspec/changes/add-drift-breaker-semantics/design.md
@@ -1,0 +1,98 @@
+## Context
+
+Bosun has two independent breaker mechanisms that the spec conflates by name but
+which are distinct in code:
+
+1. The **deploy-failure circuit breaker** (`### Requirement: Circuit Breaker` in
+   the reconcile spec) counts consecutive pipeline failures per commit and stops
+   retrying a bad commit. This change does **not** touch it.
+2. The **restart circuit breaker** (`internal/reconcile/restart_breaker.go`)
+   watches Docker container restart-count velocity and trips when a container
+   restarts too fast within a window. It has no spec requirement today.
+
+Separately, **drift self-heal** (`maybeSelfHeal`, gated by
+`BOSUN_DRIFT_SELF_HEAL`) reconciles when periodic drift is detected. It also has
+no spec requirement.
+
+All three findings are state-machine bugs: an unbounded loop, a baseline reset
+that erases accumulated signal, and a resolution check that misreads Docker's
+restart-count reset on recreation. Because these are interacting state machines
+with subtle transition edges, a design doc is warranted.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Self-heal converges to a terminal "exhausted" state for unfixable
+    (out-of-band) drift, with operator-visible signal.
+  - The restart breaker trips for sustained slow loops, not only bursty ones
+    inside a single window.
+  - Resolution detection distinguishes bosun-initiated recreation from external
+    operator recovery and from continued looping.
+- Non-Goals:
+  - Replacing the breaker with a generic rate limiter or backoff library.
+  - Auto-remediating out-of-band drift causes (the daemon cannot fix what keeps
+    mutating state outside git — bounding the attempts is the correct posture).
+  - Changing the deploy-failure circuit breaker.
+
+## Decisions
+
+- **Decision: Bound self-heal by attempts per drift signature, not wall-clock.**
+  A drift "signature" is the stable set of `service:type` items currently in
+  drift. Counting attempts per signature means a *new* problem resets the budget
+  while a *persistent unfixable* one exhausts and stops. Wall-clock backoff alone
+  would still loop forever at a slower cadence.
+  - Alternatives considered: global attempt cap (penalizes unrelated future
+    drift); pure exponential backoff (never terminates; still flaps).
+
+- **Decision: Carry forward the earliest unresolved-restart baseline.**
+  The bug is that `elapsed > window` resets the baseline to "now", discarding the
+  fact that the container has been restart-looping the whole time. Instead, when
+  restarts are still accumulating (`delta > 0`), the breaker keeps the earliest
+  baseline so a slow loop eventually crosses the threshold. A clean check
+  (`delta <= 0`) still advances the baseline normally.
+  - Alternatives considered: shrink the default window (doesn't fix the
+    misconfiguration class); rate-of-restart over absolute delta (larger change,
+    deferred).
+
+- **Decision: Track container identity + require post-recreate stability.**
+  Docker zeroes `RestartCount` on recreation, so `count <= prev.RestartCount`
+  cannot by itself mean "operator fixed it". Recording the container ID lets the
+  breaker recognize a recreation (identity changed) versus a same-container
+  recovery. After a recreation, the breaker requires at least one clean check
+  cycle (no new restarts) before declaring `Resolved`.
+  - Alternatives considered: ignore resolution entirely until manual reset (too
+    sticky); time-only grace period without identity (still misreads a recreate
+    that immediately resumes looping).
+
+- **Decision: Warn, do not hard-fail, on `drift_interval > restart_window`.**
+  The breaker observes restart counts on the drift-check cadence. If the drift
+  interval exceeds the restart window, a window-bounded delta is unobservable.
+  Carrying the baseline forward (above) makes the breaker robust to this, but the
+  config is still a smell, so config-load warns rather than silently degrading.
+
+## Risks / Trade-offs
+
+- **Exhausted self-heal could mask a transient drift that would have cleared on
+  the next attempt** → mitigated by resetting the counter on any signature change
+  and re-arming when the exhausted signature later clears.
+- **Carrying the restart baseline forward could delay a clean-state reset** →
+  mitigated by advancing the baseline normally whenever `delta <= 0`.
+- **Container-identity tracking adds a state field** → mitigated by safe decode
+  of legacy state (unknown identity treated conservatively).
+
+## Migration Plan
+
+1. New state fields (self-heal attempt counters, restart container identity)
+   default to zero values; legacy state files decode as "no prior attempts" /
+   "identity unknown".
+2. New env var `BOSUN_DRIFT_SELF_HEAL_MAX_ATTEMPTS` has a safe default; operators
+   need not set anything.
+3. Rollback: removing the bound reverts to current loop behavior; no state schema
+   break (new fields are additive).
+
+## Open Questions
+
+- Default value for `BOSUN_DRIFT_SELF_HEAL_MAX_ATTEMPTS` (lean: 3, matching the
+  deploy-failure breaker's `MaxAttempts`).
+- Whether the post-recreate stability grace period is expressed in check cycles
+  or a duration (lean: one full check cycle for simplicity).

--- a/openspec/changes/add-drift-breaker-semantics/proposal.md
+++ b/openspec/changes/add-drift-breaker-semantics/proposal.md
@@ -1,0 +1,79 @@
+# Change: Bounded drift self-heal and restart-breaker state-machine integrity
+
+## Why
+
+The April 2026 reconcile-path bug hunt (Cluster F) found three correctness gaps
+in the drift self-heal and restart circuit-breaker state machines. None of these
+mechanisms has an authoritative spec requirement to regress against.
+
+- **Self-heal has no max-attempts breaker (#259).** `maybeSelfHeal`
+  (`internal/daemon/daemon.go:923`) honors only skip-if-reconciling and
+  skip-if-cooldown. When the drift cause is out-of-band — something keeps
+  mutating Docker state outside git — `docker compose up` cannot fix it, so the
+  daemon reconciles forever at cooldown cadence: sustained alert flap, log
+  volume, zero remediation.
+- **Restart breaker resets its baseline when the window elapses (#265).**
+  `evaluateRestartBreaker` (`internal/reconcile/restart_breaker.go:71`)
+  unconditionally resets the baseline when `delta > 0` but `elapsed > window`. If
+  `BOSUN_DRIFT_INTERVAL > BOSUN_RESTART_WINDOW`, the breaker is mathematically
+  incapable of tripping — a slow restart loop never accumulates a window-bounded
+  delta. A silent no-op of a safety net.
+- **Deploy-driven recreation is mis-attributed as operator resolution (#266).**
+  The resolution branch (`restart_breaker.go:50`) marks a tripped service
+  `Resolved` when `count <= prev.RestartCount`. Docker resets `RestartCount` to 0
+  on container recreation, so a reconcile-driven recreate trivially satisfies the
+  check and fires a false "Resolved" alert even though the container has not
+  stabilized.
+
+This proposal establishes spec requirements for **bounded self-heal** and
+**restart-breaker state-machine integrity** so the daemon's automated remediation
+is correct, observable, and fail-safe.
+
+## What Changes
+
+- **Self-heal attempt bounding** — drift self-heal SHALL track attempts per
+  drift signature and stop after a bounded number of attempts when reconciling
+  does not resolve the drift, emitting an operator-visible exhausted state and
+  alert rather than looping indefinitely. This is the first spec requirement for
+  `BOSUN_DRIFT_SELF_HEAL`.
+- **Restart-breaker baseline integrity** — the restart circuit breaker SHALL NOT
+  silently reset its baseline merely because the evaluation window elapsed while
+  restarts are still accumulating; a sustained slow restart loop SHALL still
+  trip. Config-load SHALL warn when `BOSUN_DRIFT_INTERVAL > BOSUN_RESTART_WINDOW`.
+- **Drift resolution attribution** — a container recreation caused by bosun's own
+  deploy SHALL NOT be recorded as operator/external resolution of a tripped
+  restart breaker; resolution detection SHALL distinguish bosun-initiated change
+  from external change and require post-recreate stability before declaring
+  resolved.
+
+## Impact
+
+- Affected specs: `reconcile` — three ADDED requirements (Drift Self-Heal
+  Attempt Bounding, Restart Breaker Baseline Integrity, Restart Breaker
+  Resolution Attribution). No existing requirement changes behavior: the spec's
+  `### Requirement: Circuit Breaker` describes the **deploy-failure** breaker
+  (consecutive pipeline failures per commit), a distinct mechanism from the
+  **restart** breaker in `restart_breaker.go`. Self-heal has no prior requirement.
+- Affected code:
+  - `internal/daemon/daemon.go` — `maybeSelfHeal` (`:923`), self-heal cooldown
+    and trigger path
+  - `internal/reconcile/restart_breaker.go` — `evaluateRestartBreaker`
+    (resolution branch `:50`, window-reset branch `:71`),
+    `RestartTrackingEntry`, `collectRestartCounts`
+  - `internal/reconcile/reconcile.go` / state types — `DeployState` /
+    drift-status fields used to persist self-heal attempt counters keyed by drift
+    signature
+  - config-load / `ConfigFromEnv` — drift-interval vs restart-window warning
+- All consumers of the affected state:
+  - Daemon self-heal loop (`maybeSelfHeal`) — reads/writes self-heal attempt
+    state, needs its own scenarios
+  - Restart-breaker evaluation (`evaluateRestartBreaker`) — reads/writes
+    `RestartTrackingEntry`, needs its own scenarios
+  - Drift status persistence — the state file gains self-heal counters and a
+    container-identity field on restart tracking
+- New config / env vars (settled during implementation):
+  - `BOSUN_DRIFT_SELF_HEAL_MAX_ATTEMPTS` (int, bounded self-heal attempts)
+  - Restart tracking gains a container-identity field and a post-recreate
+    stability grace period
+- Docs: `skills/onboard/resources/gitops.md` (self-heal + breaker behavior),
+  `CLAUDE.md` env-var table.

--- a/openspec/changes/add-drift-breaker-semantics/specs/reconcile/spec.md
+++ b/openspec/changes/add-drift-breaker-semantics/specs/reconcile/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Drift Self-Heal Attempt Bounding
+
+Drift self-heal SHALL track reconciliation attempts per drift signature and SHALL stop attempting after a bounded number of attempts when reconciling does not resolve the drift, rather than looping indefinitely.
+
+When `BOSUN_DRIFT_SELF_HEAL` is enabled, a periodic drift check that finds drift
+MAY trigger a reconciliation. The daemon SHALL maintain, in the deploy state
+file, a per-drift-signature attempt counter, where a drift signature is the
+stable set of currently-drifted `service:type` items. The attempt bound SHALL be
+configurable via `BOSUN_DRIFT_SELF_HEAL_MAX_ATTEMPTS` with a small positive
+default.
+
+Each self-heal trigger for the current signature SHALL increment the counter.
+When the counter reaches the bound, the daemon SHALL mark the signature exhausted,
+SHALL stop triggering self-heal for that signature, and SHALL emit a
+`self-heal-exhausted` alert at most once per exhausted signature. When the drift
+signature changes, or the drifted items clear, the counter SHALL reset and an
+exhausted signature SHALL re-arm.
+
+#### Scenario: Out-of-band drift exhausts the self-heal bound
+- **WHEN** `BOSUN_DRIFT_SELF_HEAL` is enabled and a drift caused by out-of-band container state persists across self-heal attempts
+- **THEN** self-heal triggers up to the configured maximum number of attempts for that signature
+- **AND** after the bound is reached the daemon stops triggering self-heal for that signature
+- **AND** a `self-heal-exhausted` alert is emitted once
+
+#### Scenario: New drift signature resets the attempt counter
+- **WHEN** a different set of services enters drift after a prior signature was exhausted
+- **THEN** the attempt counter for the new signature starts at zero
+- **AND** self-heal may attempt reconciliation again for the new signature
+
+#### Scenario: Resolved drift re-arms an exhausted signature
+- **WHEN** a previously exhausted drift signature later clears (drift items become empty)
+- **THEN** the exhausted state for that signature is cleared
+- **AND** a subsequent recurrence of the same signature is eligible for self-heal again
+
+#### Scenario: Self-heal disabled performs no attempts
+- **WHEN** `BOSUN_DRIFT_SELF_HEAL` is disabled and a periodic drift check finds drift
+- **THEN** no self-heal reconciliation is triggered
+- **AND** no attempt counter is incremented
+
+### Requirement: Restart Breaker Baseline Integrity
+
+The restart circuit breaker SHALL NOT silently reset its restart-count baseline merely because the evaluation window elapsed while restarts are still accumulating, so that a sustained slow restart loop still trips.
+
+When evaluating a tracked service whose current restart count exceeds its
+baseline (`delta > 0`), the breaker SHALL preserve the earliest unresolved-restart
+baseline (its count and timestamp) when the elapsed time exceeds the configured
+window, rather than resetting the baseline to the current observation. The breaker
+SHALL advance the baseline normally only when no new restarts occurred since the
+last check (`delta <= 0`). A service that restarts repeatedly across intervals
+longer than `BOSUN_RESTART_WINDOW` SHALL still accumulate toward the threshold and
+trip.
+
+At configuration load, the daemon SHALL warn when `BOSUN_DRIFT_INTERVAL` is
+greater than `BOSUN_RESTART_WINDOW`, because the breaker observes restart counts
+on the drift-check cadence and a window-bounded delta would otherwise be
+unobservable.
+
+#### Scenario: Slow restart loop trips despite long drift interval
+- **WHEN** `BOSUN_DRIFT_INTERVAL` is greater than `BOSUN_RESTART_WINDOW` and a container restarts repeatedly across successive drift checks
+- **THEN** the breaker preserves the accumulating baseline rather than resetting it each interval
+- **AND** the service eventually trips the restart breaker
+
+#### Scenario: Clean check advances the baseline
+- **WHEN** a tracked service shows no new restarts since the last check (`delta <= 0`)
+- **THEN** the breaker advances the baseline to the current count and timestamp
+
+#### Scenario: Misconfigured intervals warn at load
+- **WHEN** the daemon loads configuration with `BOSUN_DRIFT_INTERVAL` greater than `BOSUN_RESTART_WINDOW`
+- **THEN** a warning is logged identifying the interval/window mismatch
+
+### Requirement: Restart Breaker Resolution Attribution
+
+The restart circuit breaker SHALL distinguish a container recreation caused by bosun's own deploy from external operator recovery and SHALL NOT record a deploy-driven recreation as resolution of a tripped service.
+
+The breaker SHALL track a container-identity field (such as the container ID)
+alongside the restart count for each tracked service. Because Docker resets a
+container's restart count to zero on recreation, a lower-or-equal restart count
+SHALL NOT by itself be treated as operator recovery. When the tracked
+container identity changes, the breaker SHALL treat the event as recreation and
+SHALL require a post-recreate stability grace period — at least one check cycle
+with no further restarts — before marking the service `Resolved`. A service that
+resumes restart-looping after recreation SHALL remain tripped.
+
+#### Scenario: Deploy-driven recreation does not falsely resolve
+- **WHEN** a tripped service is recreated by a reconcile and immediately resumes restart-looping
+- **THEN** the breaker recognizes the changed container identity as recreation
+- **AND** does not emit a `Resolved` event
+- **AND** the service remains tripped
+
+#### Scenario: Operator recovery resolves after stability
+- **WHEN** a tripped service is recreated or recovered and then runs with no further restarts across at least one check cycle
+- **THEN** the breaker marks the service `Resolved`
+
+#### Scenario: Same-container recovery requires stability
+- **WHEN** a tripped service shows a restart count that is lower or equal but the container identity is unchanged
+- **THEN** the breaker does not mark the service `Resolved` until a clean check cycle confirms stability

--- a/openspec/changes/add-drift-breaker-semantics/tasks.md
+++ b/openspec/changes/add-drift-breaker-semantics/tasks.md
@@ -1,0 +1,33 @@
+## 1. Drift self-heal attempt bounding (#259)
+
+- [ ] 1.1 Add `MaxSelfHealAttempts` to the daemon config, parsed from `BOSUN_DRIFT_SELF_HEAL_MAX_ATTEMPTS` in `ConfigFromEnv` (default a small positive value)
+- [ ] 1.2 Define a stable drift-signature key (e.g. sorted `service:type` set) and a per-signature attempt counter in the deploy state file
+- [ ] 1.3 In `maybeSelfHeal`, increment the counter for the current drift signature before triggering; reset the counter when the signature changes or drift clears
+- [ ] 1.4 Stop self-heal once the counter reaches the bound; mark the signature exhausted in state and emit a `self-heal-exhausted` alert (once per signature)
+- [ ] 1.5 Resume self-heal when a new/changed drift signature appears or the exhausted signature later clears
+- [ ] 1.6 Tests: out-of-band drift triggers self-heal N times then stops; new signature resets the counter; resolved drift clears exhausted state
+
+## 2. Restart breaker baseline integrity (#265)
+
+- [ ] 2.1 In `evaluateRestartBreaker`, when `delta > 0` and `elapsed > window`, do not silently reset the baseline to the current count; carry forward enough history that a sustained slow loop still trips
+- [ ] 2.2 Preserve the earliest unresolved-restart baseline (timestamp + count) so accumulated restarts across long intervals are not discarded
+- [ ] 2.3 At config-load, warn when `BOSUN_DRIFT_INTERVAL > BOSUN_RESTART_WINDOW` (breaker can never observe a window-bounded delta otherwise)
+- [ ] 2.4 Tests: with `drift_interval > restart_window` and a looping container, breaker trips; doctor/config-load emits the misconfiguration warning
+
+## 3. Restart breaker resolution attribution (#266)
+
+- [ ] 3.1 Add a container-identity field (e.g. container ID) to `RestartTrackingEntry`
+- [ ] 3.2 Capture the container identity when a service is first tracked / tripped
+- [ ] 3.3 In the resolution branch, treat a changed container identity as recreation (not operator recovery); do not mark `Resolved` on a `RestartCount` reset that is explained by recreation
+- [ ] 3.4 Require a post-recreate stability grace period (no further restarts across at least one check cycle) before declaring `Resolved`
+- [ ] 3.5 Tests: reconcile-driven recreate does not emit `Resolved` while the container resumes looping; genuine operator recovery (stable, same or new container) does emit `Resolved`
+
+## 4. State persistence & migration
+
+- [ ] 4.1 Persist self-heal attempt counters and restart container-identity fields via the existing atomic write pattern
+- [ ] 4.2 Ensure missing/legacy fields decode safely (zero values behave as "no prior attempts" / "identity unknown")
+
+## 5. Documentation
+
+- [ ] 5.1 Update `skills/onboard/resources/gitops.md` (self-heal bounding + restart-breaker semantics)
+- [ ] 5.2 Add new env vars to the `CLAUDE.md` env-var table


### PR DESCRIPTION
## Summary

Spec-only proposal (Cluster F, reconcile half) establishing requirements for the
drift self-heal and restart circuit-breaker state machines, which currently have
no authoritative spec to regress against. Three **ADDED** requirements in
`reconcile` — no implementation code, no behavior change to the existing
deploy-failure `Circuit Breaker` requirement (a distinct mechanism).

## Findings

| Issue | Problem | Requirement |
|-------|---------|-------------|
| #259 | Drift self-heal has no max-attempts breaker — sustained loop when the cause is out-of-band | Drift Self-Heal Attempt Bounding |
| #265 | Restart breaker resets its baseline when `elapsed > window`, masking slow restart loops | Restart Breaker Baseline Integrity |
| #266 | Deploy-driven recreation mis-counted as operator resolution of a tripped service | Restart Breaker Resolution Attribution |

## Scope

- **Spec-only / Wave 1** — proposal, tasks, design, and reconcile delta only. No
  Go changes. Implementation gated on `ready-to-build`.
- `openspec validate add-drift-breaker-semantics --strict` → valid.

Refs bosun-afx

## Test plan

- [ ] CodeRabbit review converges (0 actionable / only stale)
- [ ] `openspec validate add-drift-breaker-semantics --strict` passes in CI
- [ ] Requirements map 1:1 to #259/#265/#266
- [ ] Each requirement keeps its SHALL/MUST clause on line 1 (validator gotcha)