### PR TITLE
spec: add-drift-alert-delivery — deliver-then-record drift alerts (Cluster F)

### DIFF
--- a/openspec/changes/add-drift-alert-delivery/design.md
+++ b/openspec/changes/add-drift-alert-delivery/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Drift alerting threads through three places: `RunDriftCheck` (filters the raw
+drift report through ignore rules), the daemon's drift branch (`sendDriftAlert`
++ `DriftAlertedItems` bookkeeping), and the `alert.Manager` fan-out (already
+specced for partial-failure aggregation). The three findings in this cluster all
+stem from the *order* and *inputs* of those steps: state is recorded before
+delivery is confirmed (#235), resolution is computed against the filtered list
+instead of the real one (#258), and ignore rules are never validated (#236).
+The fix is small in code but has a sharp ordering contract worth pinning in the
+spec, hence this short design note.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Make dedup/throttle state advance only on confirmed delivery, reusing the
+    existing `alert.Manager` aggregated-error contract.
+  - Make "resolved" mean "left the unfiltered drift report," never "got
+    suppressed by a new ignore rule."
+  - Fail fast on malformed ignore rules at load instead of silently
+    over-suppressing.
+- Non-Goals:
+  - New retry/backoff scheduler for failed providers (the next periodic drift
+    check is the retry; an explicit backoff is a separate concern).
+  - New drift types or changes to the detection algorithm.
+  - New env vars.
+
+## Decisions
+
+- **Decision: `sendDriftAlert` returns an error; caller gates state on success.**
+  The `alert.Manager` already returns an aggregated error and "nil when no
+  providers configured." `sendDriftAlert` simply propagates it. The caller treats
+  nil as "delivered (or nothing to deliver)" and advances state; non-nil leaves
+  `DriftAlertedItems` untouched so the next check retries. Partial success (≥1
+  provider delivered) counts as delivered — re-alerting only the failed providers
+  is out of scope and the dedup key is per-item, not per-provider.
+  - Alternatives considered: track per-provider delivery (over-engineered for the
+    per-item dedup model); swallow errors but log louder (does not fix the silent
+    throttle advance).
+
+- **Decision: Compute resolution against the unfiltered drift report.**
+  Ignore-rule filtering happens after detection. Resolution must compare the
+  previously-alerted keys against the set of items that are *truly* gone from the
+  raw report, not merely filtered out. Keys that vanished only because a new
+  ignore rule matched them are removed from `DriftAlertedItems` silently (no
+  resolution alert), preserving the dedup map's integrity without lying about
+  state.
+  - Alternatives considered: alert "drift now ignored" instead of "resolved"
+    (extra noise; the operator just authored the rule).
+
+- **Decision: Validate ignore rules at config load, fail-fast.**
+  `type` is validated against the implemented enum plus the literal `*`; globs
+  are validated with `filepath.Match("", pattern)`; a both-`*` rule is treated as
+  a total-suppression footgun. Load-time validation surfaces via `bosun validate`
+  and daemon startup, matching the existing config-validation posture.
+  - Open: total-suppression as hard error vs loud warning — see Open Questions.
+
+## Risks / Trade-offs
+
+- **Fail-fast on ignore rules could break a daemon that currently starts with an
+  invalid rule** → that rule is already a silent no-op or a total mute; surfacing
+  it is the point. Document in the migration note.
+- **Treating partial delivery as success** → an item delivered to 1 of 3
+  providers won't re-alert until cooldown. Acceptable: the operator was notified;
+  provider-level reliability is a separate concern.
+
+## Migration Plan
+
+1. Operators with malformed `drift_ignore` rules (unknown `type`, bad glob): the
+   daemon/`bosun validate` now errors at load — fix the rule to a valid type/glob.
+2. Operators relying on a `service: "*"` + `type: "*"` rule to mute all drift:
+   replace with explicit per-service/type rules (or the documented opt-out path).
+3. Rollback: revert the change set; ordering reverts to record-before-deliver.
+
+## Open Questions
+
+- Total-suppression rule (`*`/`*`): hard error or loud warning that still
+  applies? Lean: error in `bosun validate`, warning at daemon startup so an
+  intentional full mute is possible but never silent. Settle during
+  implementation.

--- a/openspec/changes/add-drift-alert-delivery/proposal.md
+++ b/openspec/changes/add-drift-alert-delivery/proposal.md
@@ -1,0 +1,81 @@
+# Change: Drift alert delivery correctness
+
+## Why
+
+The April 2026 bug hunt (Cluster F, alerting half) found three correctness gaps
+in how the daemon delivers and suppresses drift alerts. All three leave the
+operator misinformed about the actual state of their fleet:
+
+- **Silent alert drop on provider failure (#235, P0).** The daemon records a
+  drift item in `DriftAlertedItems` immediately after calling `sendDriftAlert`,
+  regardless of whether any provider actually delivered. `sendDriftAlert`
+  discards its result and logs at warn level. When Discord/SendGrid is
+  unreachable (DNS failure, 5xx, rate limit) the throttle still advances, so the
+  operator is silently in the dark for the full cooldown (default 1h) on every
+  drift event.
+- **Spurious "drift resolved" alert from ignore-rule suppression (#258, P1).**
+  `RunDriftCheck` filters `report.Items` through ignore rules *after* detection.
+  The daemon branches on the post-filter list, so adding an ignore rule that
+  suppresses a currently-drifting item makes it look resolved — the daemon sends
+  "Drift Resolved: traefik:unhealthy" while traefik is still unhealthy.
+- **Ignore rules silently accept garbage (#236, P0).** Drift ignore rules accept
+  undocumented `type` values (the in-code doc claims `stopped`, `extra`, `*` but
+  only `missing`/`image_mismatch`/`unhealthy` are implemented) and invalid glob
+  patterns (a `filepath.Match` error falls through to "no match"). An operator
+  who types `type: stopped` gets a rule that silently never matches; a typo into
+  `service: "*"` total-mutes drift detection with no warning.
+
+There is no spec describing drift-alert delivery ordering, the
+resolution-vs-suppression distinction, or ignore-rule validation, so these are
+implementation gaps with no authoritative requirement to regress against.
+
+## What Changes
+
+- **Deliver-then-record** — drift alert dedup/throttle state (`DriftAlertedItems`,
+  `DriftAlertedAt`) SHALL be updated only after delivery is confirmed by at least
+  one provider. A provider failure SHALL NOT mark the alert as delivered, so the
+  next drift check retries. The "no providers configured" case still counts as a
+  no-op success (nothing to deliver).
+- **Resolution vs suppression** — a "drift resolved" alert SHALL NOT fire when the
+  apparent resolution is caused by ignore-rule suppression. Resolution must
+  reflect actual state convergence (the item left the *unfiltered* drift report),
+  not the appearance of an item dropping out of the filtered list.
+- **Ignore-rule validation** — drift ignore rules SHALL reject undocumented `type`
+  values and invalid glob patterns at config load (fail-fast), and SHALL surface
+  a total-suppression rule (`service: "*"`, `type: "*"`) as an error or loud
+  warning, rather than silently over-suppressing all drift.
+
+## Impact
+
+- Affected specs:
+  - `alerting` — ADDED: Drift Alert Delivery Confirmation, Drift Resolution vs
+    Suppression. (Builds on existing Drift Alert Deduplication, Drift Resolution
+    Alerts, Multi-Provider Error Handling, Alert Throttling.)
+  - `reconcile` — ADDED: Drift Ignore Rule Validation (ignore rules are a config
+    surface that filters the drift report in `RunDriftCheck`).
+- Affected code:
+  - `internal/daemon/daemon.go:842-852`, `:1013-1032` — `sendDriftAlert` call
+    sites that record `DriftAlertedItems` unconditionally; `:781` (HasDrift
+    branch) vs `:877-899` (no-drift / resolution branch)
+  - `internal/reconcile/drift.go:421-432` — ignore-rule filter applied to
+    `report.Items`; `:36-39` — the in-code ignore-rule doc comment
+  - `internal/reconcile/pure.go:236-245` — ignore-rule match logic
+    (`filepath.Match` error swallowed)
+  - `internal/reconcile/state.go:30-37` — implemented `DriftType` values
+  - config load / validation path that parses `drift_ignore` and
+    `BOSUN_DRIFT_IGNORE`
+- All consumers of the drift-alert and ignore-rule surface (each needs its own
+  scenario + task):
+  - Daemon periodic drift check (`RunDriftCheck` → `sendDriftAlert`)
+  - Drift resolution branch (no-drift / partially-cleared)
+  - Multi-provider delivery (some providers succeed, some fail)
+  - Config file `drift_ignore` and `BOSUN_DRIFT_IGNORE` env-var override
+- New behavior is fail-fast at load and fail-safe at delivery; no new env vars.
+- Docs: `skills/onboard/resources/gitops.md` (drift alert delivery + ignore-rule
+  validation), `skills/onboard/resources/configuration.md` (`drift_ignore`
+  schema), `CLAUDE.md` (`BOSUN_DRIFT_IGNORE` note on validation).
+
+## Scope
+
+Spec-only (Wave 1). No implementation in this PR. Implementation begins after the
+spec PR is labeled `ready-to-build`.

--- a/openspec/changes/add-drift-alert-delivery/specs/alerting/spec.md
+++ b/openspec/changes/add-drift-alert-delivery/specs/alerting/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Drift Alert Delivery Confirmation
+
+Drift alert deduplication and throttle state SHALL be updated only after delivery is confirmed by at least one configured provider; a provider failure SHALL NOT mark a drift item as alerted.
+
+The `drift_alerted_items` map and `drift_alerted_at` timestamp SHALL be updated for a drift item only when the underlying alert dispatch succeeds (the alert manager returns nil). When the alert manager returns an aggregated error indicating all providers failed, the item's per-item cooldown state SHALL remain unchanged so the next drift check re-attempts delivery.
+
+Delivery to a configured set of providers SHALL count as confirmed when at least one provider succeeds. The "no providers configured" case (alert manager returns nil without sending) SHALL count as a confirmed no-op success, because there is nothing to deliver.
+
+State SHALL be persisted to the deploy state file only after this gated update, so a transient provider outage never advances the throttle without a delivered alert.
+
+#### Scenario: Provider failure does not advance throttle state
+
+- **WHEN** a drift item is newly detected and the alert manager returns an error indicating delivery failed
+- **THEN** the item is NOT recorded in `drift_alerted_items`
+- **AND** `drift_alerted_at` is unchanged
+- **AND** the next drift check re-attempts the alert for that item
+
+#### Scenario: Confirmed delivery advances throttle state
+
+- **WHEN** a drift item is newly detected and the alert manager returns nil
+- **THEN** the item is recorded in `drift_alerted_items` with the current timestamp
+- **AND** the item is suppressed on subsequent checks within its cooldown
+
+#### Scenario: One provider succeeds, another fails
+
+- **WHEN** a drift alert is dispatched to two providers and exactly one provider delivers successfully
+- **THEN** delivery is treated as confirmed
+- **AND** the item is recorded in `drift_alerted_items` exactly once
+
+#### Scenario: All providers fail
+
+- **WHEN** a drift alert is dispatched to two providers and both fail
+- **THEN** the item is NOT recorded in `drift_alerted_items`
+- **AND** state is not persisted as alerted for that item
+
+#### Scenario: No providers configured is a no-op success
+
+- **WHEN** a drift item is detected and no alert providers are configured
+- **THEN** the alert manager returns nil without making network calls
+- **AND** the item is recorded in `drift_alerted_items` as a confirmed no-op
+
+### Requirement: Drift Resolution vs Suppression
+
+A drift resolution alert SHALL NOT fire when the apparent resolution is caused by ignore-rule suppression of a still-drifting item; resolution MUST reflect actual state convergence.
+
+A previously-alerted drift item SHALL be considered resolved only when it is absent from the *unfiltered* drift report (the raw declared-vs-actual comparison before ignore rules are applied). An item that is still present in the unfiltered report but removed by a newly-matching ignore rule SHALL NOT be treated as resolved.
+
+When a previously-alerted item disappears from the alerted set solely because an ignore rule now matches it, the item SHALL be removed from `drift_alerted_items` without emitting a resolution alert, so the dedup map stays consistent without misreporting state.
+
+Genuinely-cleared items (absent from the unfiltered report) SHALL still trigger resolution alerts and be removed from `drift_alerted_items`, subject to the existing `BOSUN_DRIFT_RESOLVE_ALERTS` setting.
+
+#### Scenario: Ignore rule suppresses an actively-drifting item
+
+- **GIVEN** `traefik:unhealthy` is present in `drift_alerted_items`
+- **AND** traefik is still unhealthy in the unfiltered drift report
+- **WHEN** an ignore rule for `{service: traefik, type: unhealthy}` is added and the next drift check runs
+- **THEN** no "Drift Resolved" alert is sent for `traefik:unhealthy`
+- **AND** the key is removed from `drift_alerted_items`
+
+#### Scenario: Genuinely cleared item resolves normally
+
+- **GIVEN** `traefik:unhealthy` is present in `drift_alerted_items`
+- **AND** no ignore rule matches it
+- **WHEN** the next drift check finds traefik healthy and `traefik:unhealthy` absent from the unfiltered report
+- **THEN** a "Drift Resolved" alert is sent listing `traefik:unhealthy`
+- **AND** the key is removed from `drift_alerted_items`
+
+#### Scenario: Mixed clear and suppression in one check
+
+- **GIVEN** `traefik:unhealthy` and `gatus:missing` are both in `drift_alerted_items`
+- **AND** an ignore rule is added that matches `traefik:unhealthy` while traefik stays unhealthy
+- **AND** `gatus:missing` genuinely clears in the unfiltered report
+- **WHEN** the next drift check runs
+- **THEN** a resolution alert is sent for `gatus:missing` only
+- **AND** both keys are removed from `drift_alerted_items`

--- a/openspec/changes/add-drift-alert-delivery/specs/reconcile/spec.md
+++ b/openspec/changes/add-drift-alert-delivery/specs/reconcile/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Drift Ignore Rule Validation
+
+Drift ignore rules SHALL be validated at configuration load time and SHALL reject undocumented `type` values and invalid glob patterns, rather than silently accepting them and over-suppressing drift.
+
+Each ignore rule's `type` field SHALL be validated against the implemented drift-type enum (`missing`, `image_mismatch`, `unhealthy`) plus the literal `*` wildcard. An unknown `type` value SHALL produce a load-time error naming the offending rule, because such a rule would silently never match and leave drift unreported.
+
+Each ignore rule's `service` and `type` glob patterns SHALL be validated with `filepath.Match`. A pattern that returns a match error (e.g., an unclosed character class like `[unclosed`) SHALL be rejected at load time rather than silently treated as a non-match.
+
+A total-suppression rule, where both `service` and `type` are `*`, SHALL NOT be accepted silently. It SHALL surface as a load-time error (or, where an intentional full mute is supported, a loud startup warning), because it disables the entire drift system.
+
+This validation SHALL apply to ignore rules from the `drift_ignore` config-file key and to the `BOSUN_DRIFT_IGNORE` environment-variable JSON override with identical semantics.
+
+#### Scenario: Unknown drift type is rejected
+
+- **WHEN** a `drift_ignore` rule specifies `type: stopped` (not an implemented drift type)
+- **THEN** configuration load fails with an error identifying the invalid rule
+- **AND** the daemon does not start with the malformed rule
+
+#### Scenario: Invalid glob pattern is rejected
+
+- **WHEN** a `drift_ignore` rule specifies `service: "[unclosed"`
+- **THEN** configuration load fails with a glob-validation error
+- **AND** the rule is not silently treated as a non-match
+
+#### Scenario: Total-suppression rule is not silently accepted
+
+- **WHEN** a `drift_ignore` rule specifies `{service: "*", type: "*"}`
+- **THEN** configuration load surfaces it as an error or loud warning
+- **AND** drift detection is not silently disabled without operator awareness
+
+#### Scenario: Valid rules are accepted
+
+- **WHEN** a `drift_ignore` rule specifies `{service: "traefik", type: "unhealthy"}`
+- **THEN** configuration load succeeds
+- **AND** the rule suppresses matching drift items at check time
+
+#### Scenario: Env-var override is validated identically
+
+- **WHEN** `BOSUN_DRIFT_IGNORE` contains a rule with an unknown `type` value
+- **THEN** the override fails validation at load with the same error as the config-file path

--- a/openspec/changes/add-drift-alert-delivery/tasks.md
+++ b/openspec/changes/add-drift-alert-delivery/tasks.md
@@ -1,0 +1,29 @@
+## 1. Deliver-then-record drift alerts (#235)
+
+- [ ] 1.1 Change `sendDriftAlert` to return an error reflecting delivery outcome (propagate the `alert.Manager` result; treat "no providers configured" as success)
+- [ ] 1.2 In the HasDrift branch (`daemon.go:842-852`), update `DriftAlertedItems[key]` and `DriftAlertedAt` only when delivery succeeds for at least one provider
+- [ ] 1.3 In the resolution branch (`daemon.go:1013-1032`), gate the removal/clear of `DriftAlertedItems` on confirmed resolution-alert delivery the same way
+- [ ] 1.4 Persist state only after the gated update so a provider failure leaves throttle state unchanged and the next check retries
+- [ ] 1.5 Tests: provider returns error → `DriftAlertedItems` unchanged + next check re-attempts; all providers fail → no state advance; one of N providers succeeds → state advances once
+
+## 2. Resolution vs ignore-rule suppression (#258)
+
+- [ ] 2.1 Distinguish items absent from the current check because they actually cleared vs because an ignore rule now suppresses them (compare against the unfiltered drift report, or tag suppressed keys)
+- [ ] 2.2 Suppress the "Drift Resolved" alert for keys that disappeared only due to ignore-rule suppression
+- [ ] 2.3 Still remove genuinely-cleared keys from `DriftAlertedItems`; remove suppressed keys without emitting a resolution alert
+- [ ] 2.4 Tests: add ignore rule for an actively-drifting alerted item → no resolution alert, item still unhealthy; item that truly clears → resolution alert fires
+
+## 3. Ignore-rule validation at config load (#236)
+
+- [ ] 3.1 Validate each `drift_ignore` rule `type` against the implemented enum (`missing`, `image_mismatch`, `unhealthy`, and the literal `*` wildcard) and error on unknown values
+- [ ] 3.2 Validate each `service` and `type` glob with `filepath.Match` and reject patterns that error
+- [ ] 3.3 Reject (or loudly warn on, per design decision) a total-suppression rule where both `service` and `type` are `*`
+- [ ] 3.4 Apply the same validation to `BOSUN_DRIFT_IGNORE` JSON overrides
+- [ ] 3.5 Reconcile the in-code doc comment (`drift.go:36-39`) with the actual implemented types
+- [ ] 3.6 Tests: unknown type rejected, invalid glob rejected, total-suppression rule rejected/warned, valid rules accepted; `bosun validate` surfaces the error
+
+## 4. Documentation
+
+- [ ] 4.1 Update `skills/onboard/resources/gitops.md` (drift alert delivery semantics + ignore-rule validation)
+- [ ] 4.2 Update `skills/onboard/resources/configuration.md` (`drift_ignore` schema and accepted `type` values)
+- [ ] 4.3 Note ignore-rule validation behavior alongside `BOSUN_DRIFT_IGNORE` in `CLAUDE.md`


### PR DESCRIPTION
## Summary

Spec-only change proposal (Cluster F, alerting half) covering drift alert delivery correctness. Establishes three ADDED requirements so the daemon never misreports drift state to the operator: confirm delivery before recording throttle state, distinguish resolution from ignore-rule suppression, and validate ignore rules at config load.

## Findings

| Issue | Sev | Gap | Requirement |
|-------|-----|-----|-------------|
| #235 | P0 | Alert state recorded before delivery confirmed — provider failure silently drops the alert and advances the throttle | Drift Alert Delivery Confirmation (`alerting`) |
| #258 | P1 | Spurious "drift resolved" alert when ignore rules suppress newly-added drift | Drift Resolution vs Suppression (`alerting`) |
| #236 | P0 | Ignore rules silently accept undocumented `type` values and invalid globs (total-suppression footgun) | Drift Ignore Rule Validation (`reconcile`) |

## Deltas

- `specs/alerting/spec.md` — ADDED: Drift Alert Delivery Confirmation, Drift Resolution vs Suppression (builds on existing Drift Alert Deduplication, Drift Resolution Alerts, Multi-Provider Error Handling)
- `specs/reconcile/spec.md` — ADDED: Drift Ignore Rule Validation (ignore rules filter the drift report in `RunDriftCheck`; validation is fail-fast at config load, applies to both `drift_ignore` and `BOSUN_DRIFT_IGNORE`)

Includes a short `design.md` for the delivery-ordering contract. `openspec validate add-drift-alert-delivery --strict` passes clean.

## Scope

Spec-only (Wave 1). No implementation in this PR — implementation begins after `ready-to-build` is applied. Refs bosun-hqh.

## Test plan

- [ ] CodeRabbit review converges (0 actionable / only stale)
- [ ] `openspec validate add-drift-alert-delivery --strict` green in CI
- [ ] Scenarios cover multi-provider partial failure, suppression-vs-resolution, and env-var override parity
- [ ] Spec stable → label `ready-to-build`