### PR TITLE
spec: add-reconcile-fuse-hooks — FUSE-safe post-deploy hooks (Cluster D)

### DIFF
--- a/openspec/changes/add-reconcile-fuse-hooks/design.md
+++ b/openspec/changes/add-reconcile-fuse-hooks/design.md
@@ -1,0 +1,113 @@
+## Context
+
+Post-sync hooks are bosun's documented answer to Unraid's FUSE (shfs) config
+propagation problem: after a config file syncs, a service like Traefik watching a
+different FUSE handle won't see the write for several seconds, so bosun restarts
+the container to force a re-read. The pipeline that drives this — glob matching,
+the change set the matcher evaluates, the timing of the restart relative to the
+write becoming durably visible, and the hot-reload of hook config — has several
+silent-failure modes discovered in the Cluster D bug hunt. Each makes a hook
+report success while doing nothing the operator can observe.
+
+Two properties make these bugs pernicious: they are silent (success logs fire
+regardless), and they manifest precisely on the FUSE target bosun was built for,
+so an operator running on a non-FUSE local disk during testing never reproduces
+them.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Glob semantics that are correct and identical everywhere `matchGlob` is used,
+    including the `deploy_paths` family — one matcher, one behavior.
+  - Hooks fire only after written files are durably visible on the target
+    filesystem, with a safe-by-default delay rather than a footgun `0`.
+  - Every "hook did nothing" path is observable: typo'd glob, empty command,
+    deletion-only commit, verification failure.
+  - Hot-reload distinguishes "key absent" from "key explicitly set", so an
+    operator's FUSE workaround is never silently dropped.
+- Non-Goals:
+  - A general file-watch / inotify replacement for restart hooks.
+  - Cross-platform FUSE detection beyond a best-effort heuristic for the doctor
+    warning (the safe non-zero default protects operators who aren't detected).
+  - New hook actions beyond the existing `restart` / `exec`.
+
+## Decisions
+
+- **Decision: Replace the hand-rolled `**` prefix check with full doublestar
+  semantics.** The current matcher (`strings.SplitN(pattern, "**", 2)[0]`) throws
+  away the suffix and short-circuits `**/foo` to match-everything. Adopt a real
+  doublestar implementation (`github.com/bmatcuk/doublestar/v4`) or a vetted
+  glob→regex translation so `appdata/**/dynamic.yml`, `**/dynamic.yml`, and
+  `traefik/**/*.yml` all evaluate correctly. Because `matchAnyPath` shares this
+  matcher, the fix is spec'd as a single glob-correctness requirement covering
+  hooks AND the deploy-path family.
+  - Alternatives considered: keep prefix-only and validate patterns at load to
+    reject `**`-with-suffix (rejected — silently weakens the documented feature).
+
+- **Decision: Two-part FUSE safety — directory fsync + non-zero settle default.**
+  fsync of the destination directory after rename makes the rename durable in the
+  underlying filesystem; the settle delay covers the *propagation* window where
+  FUSE caches still serve stale entries to other handles. Both are needed: fsync
+  alone doesn't defeat client-side FUSE caching, and a delay alone doesn't
+  guarantee the rename hit disk. Default `HookSettleDelay` to a safe non-zero
+  value (e.g. `2s`); `doctor` warns when a FUSE-like target path runs with `0s`.
+  - Alternatives considered: poll the target for the new content hash before
+    firing (more robust but requires reading back through the same FUSE handle the
+    service uses, which bosun doesn't have; keep as a future enhancement).
+
+- **Decision: Track deletions in the change set the hook matcher consults.**
+  `removeStaleFiles` deletions are appended to `WrittenFiles` (or a parallel
+  `DeletedFiles` the matcher unions), tagged with an op (`add` | `remove`) so a
+  future hook can filter. The minimum bar: a deletion-only commit that matches a
+  hook pattern fires the hook. This is also why the empty-match early return
+  (#269) must move *below* the deletion merge — otherwise deletions are merged but
+  the function still returns before evaluating them.
+
+- **Decision: Verification failure is a recorded write, not a void.** A
+  `CopyFileIfChanged` that renames successfully but fails post-write hash readback
+  (a FUSE-staleness symptom) still records the path as written so the hook fires;
+  the alternative is to propagate the failure as a hard error. Silent omission —
+  the current behavior — is the one outcome the spec forbids.
+
+- **Decision: Pointer-typed reload DTO fields.** `post_sync_hooks` and
+  `hook_settle_delay` reload DTO fields become `*[]PostSyncHook` / `*time.Duration`
+  so YAML decoding yields `nil` for an absent key and a non-nil value (including
+  an explicit empty slice or `0s`) for a present one. The reloader overwrites only
+  on non-nil. Absent key ⇒ retain prior value; `post_sync_hooks: []` ⇒ clear;
+  `hook_settle_delay: 0s` ⇒ explicitly zero.
+  - Alternatives considered: document "use `[]` to clear" without code change
+    (rejected for the delay — there's no in-band way to express "absent" today, so
+    it always zeroes).
+
+## Risks / Trade-offs
+
+- **Glob correctness is a behavior change** → patterns relying on the old
+  prefix-only luck may stop matching. Mitigated by treating it as a documented
+  breaking fix and by the new no-match warning making regressions discoverable.
+- **Non-zero settle-delay default slows every deploy slightly** → mitigated by a
+  small default (~2s) and operator override to `0s` on non-FUSE targets.
+- **New dependency (doublestar)** → small, widely used, MIT; vetted as part of
+  implementation.
+- **Deletion tracking could over-fire hooks** on large prune commits → mitigated
+  by per-container dedup (already "restart at most once per deploy").
+
+## Migration Plan
+
+1. Operators relying on prefix-only glob behavior: review `post_sync_hooks` and
+   `deploy_paths` patterns against the new no-match warning after first deploy.
+2. Operators on non-FUSE local disk who want the old instant behavior: set
+   `BOSUN_HOOK_SETTLE_DELAY=0s` (or `hook_settle_delay: 0s`) explicitly.
+3. Operators clearing hooks via hot-reload: replace section removal with
+   `post_sync_hooks: []`.
+4. Rollback: revert the matcher and default; pointer DTO fields are
+   backwards-compatible to read.
+
+## Open Questions
+
+- Exact safe default for `HookSettleDelay` (`2s` proposed) — settle during
+  implementation against real Unraid propagation measurements.
+- FUSE detection heuristic for the doctor warning: statfs magic vs. mount-table
+  inspection vs. path prefix (`/mnt/user`). Lean: statfs `f_type` where available,
+  fall back to warn-always-on-zero.
+- Whether deletion entries should default to firing `restart` hooks only, or also
+  `exec` hooks (lean: both; dedup protects against storms).

--- a/openspec/changes/add-reconcile-fuse-hooks/proposal.md
+++ b/openspec/changes/add-reconcile-fuse-hooks/proposal.md
@@ -1,0 +1,102 @@
+# Change: FUSE-safe post-deploy hooks and glob correctness
+
+## Why
+
+The April 2026 reconcile-path bug hunt (Cluster D) found that the post-sync hook
+pipeline — the exact mechanism bosun ships to work around Unraid's FUSE config
+propagation — has multiple silent-failure modes that make a hook report success
+while never actually firing or never being seen by the target service.
+
+The glob matcher does a prefix-only check and discards everything after `**`, so
+suffix filters (`appdata/**/dynamic.yml`) silently degrade and any `**/foo`
+pattern matches every changed file (#232, P0). Because the same matcher backs
+`deploy_paths` / `deploy_sync_paths` / `deploy_sync_exclude`, this corrupts
+path-aware deploy skipping too. Hooks fire synchronously after a write returns,
+but `HookSettleDelay` defaults to `0` and the destination directory is never
+fsynced — on FUSE the renamed config is invisible when the hook restarts the
+container, so Traefik re-reads stale config and the "Restarted traefik" log lies
+(#233, P0). Deletion-only commits remove files via `removeStaleFiles` but never
+record them in `WrittenFiles`, so the hook matcher sees zero changes and never
+fires — stale prod routes persist (#234, P0). A typo'd glob that matches nothing
+returns silently and no-ops forever (#269, P1). Hot-reload of `bosun.yaml`
+silently zeroes `HookSettleDelay` and drops `post_sync_hooks` when the keys are
+absent, regressing an operator's FUSE workaround weeks later (#267 / #268, P1).
+An `exec` hook with an empty command is silently skipped (#283, P2), and a
+post-write content-verification failure makes a file silently miss future hooks
+(#282, P2).
+
+There is no spec describing FUSE-safe timing or glob semantics, so these are
+implementation gaps with no authoritative requirement to regress against. This
+proposal adds a `reconcile-fuse-hooks` capability for glob/timing/observability
+correctness and modifies the existing `reconcile` "Post-Sync Container Restart
+Hooks" requirement to cover deletion-aware change tracking and empty-command
+rejection.
+
+## What Changes
+
+- **Glob matching correctness (#232)** — recursive `**` matching SHALL honor the
+  suffix after `**`; suffix and infix filters work, and `**/foo` SHALL NOT match
+  unrelated files. **BREAKING**: patterns previously matching by prefix-only luck
+  may stop matching; this corrects silently-wrong semantics shared with
+  `deploy_paths`.
+- **FUSE-safe hook timing (#233)** — the reconciler SHALL fsync each destination
+  directory after writing files and SHALL apply a non-zero settle delay before
+  running post-sync hooks, with a safe default rather than `0`, and `doctor`
+  SHALL warn when a FUSE-like target runs with a zero delay.
+- **Deletion-aware hooks (#234)** — deletion-only commits SHALL record removed
+  paths in the deploy change set so matching hooks fire. **MODIFIED** reconcile
+  requirement.
+- **Hook match observability (#269)** — when configured hooks evaluate changed
+  files and nothing matches, the reconciler SHALL emit a discoverable warning
+  naming the patterns and sample files.
+- **Empty hook command rejection (#283)** — a hook whose action requires a
+  command (`exec`) with an empty command SHALL be a config-load error, not a
+  silent skip. **MODIFIED** reconcile requirement.
+- **Post-write verification propagation (#282)** — a successful write whose
+  post-write content verification fails SHALL still be recorded as written (so
+  the hook fires) or SHALL surface as an error; it SHALL NOT silently vanish from
+  the change set.
+- **Hot-reload removal semantics (#267 / #268)** — absent `post_sync_hooks` /
+  `hook_settle_delay` keys on hot-reload SHALL retain the prior in-memory value
+  (DTO pointer fields distinguish "absent" from "explicitly set"); operators
+  clear hooks with `post_sync_hooks: []` and reset the delay with an explicit
+  `hook_settle_delay: 0s`.
+
+## Impact
+
+- Affected specs: NEW capability `reconcile-fuse-hooks`; MODIFIED requirement
+  `Post-Sync Container Restart Hooks` in `reconcile`.
+- Affected code:
+  - `internal/reconcile/hooks.go` — `matchGlob` (`:105-122`), hook execution
+    loop and empty-command skip (`:139-155`, `:188-194`), settle-delay
+    application
+  - `internal/reconcile/reconcile.go` — `executePostSyncHooks` empty-match early
+    return (`:769-786`)
+  - `internal/reconcile/deploy.go` — `removeStaleFiles` (`:155-158`, `:251-299`),
+    `WrittenFiles` accumulation, post-write verification handling (`:314-321`)
+  - `internal/fileutil/fileutil.go` — `CopyFile` (no dir fsync after rename,
+    `:60-110`), `CopyFileIfChanged` post-write verification (`:217-221`)
+  - `internal/reconcile/config_reload.go` — reload predicates (`:36`, `:38-41`)
+  - `internal/reconcile/configfield.go` — `PostSyncHook` reload field (`:59-66`)
+  - `internal/daemon/daemon.go` — `ReloadedConfig{HookSettleDelay}` build
+    (`:1621-1624`)
+  - `internal/config` — `PostSyncHook` DTO + validation, `HookSettleDelay`
+    parsing
+  - `internal/preflight` — `doctor` FUSE/zero-delay check
+- All consumers of the glob matcher and hook change set (each needs its own
+  scenario + task):
+  - `matchGlob` callers: post-sync hook path matching (`hooks.go`), `matchAnyPath`
+    for `deploy_paths` / `deploy_sync_paths` / `deploy_sync_exclude`
+    (`deploy.go` path-aware skip)
+  - hook change-set producers: `CopyDirIfChanged` (added/changed),
+    `removeStaleFiles` (deleted), git-diff fallback
+  - hot-reload consumers: daemon reloader (`daemon.go`), `config_reload.go`
+    appliers for `PostSyncHooks` and `HookSettleDelay`
+- New / changed config + env vars:
+  - `BOSUN_HOOK_SETTLE_DELAY` default becomes a non-zero safe value (documented
+    breaking default change)
+  - `post_sync_hooks` / `hook_settle_delay` DTO fields become pointer-typed for
+    absent-vs-set distinction (internal; affects reload semantics)
+- Docs: `skills/onboard/resources/gitops.md` (hook timing, FUSE), `docs/gitops.md`
+  / `docs/troubleshooting.md`, `CLAUDE.md` env-var table (settle-delay default,
+  reload semantics).

--- a/openspec/changes/add-reconcile-fuse-hooks/specs/reconcile-fuse-hooks/spec.md
+++ b/openspec/changes/add-reconcile-fuse-hooks/specs/reconcile-fuse-hooks/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: Recursive Glob Matching Correctness
+
+The glob matcher SHALL honor the full pattern including any literal suffix that follows a `**` segment, and SHALL NOT collapse a `**` pattern to a prefix-only check. A pattern beginning with `**/` SHALL match a file only when the remainder of the pattern matches the file's trailing path segments, and SHALL NOT match every changed file unconditionally.
+
+The same matcher backs post-sync hook path matching and the `deploy_paths`, `deploy_sync_paths`, and `deploy_sync_exclude` evaluation used for path-aware deploy skipping, so the corrected semantics SHALL apply identically to all of them.
+
+#### Scenario: Suffix after recursive segment is honored
+
+- **WHEN** a hook pattern is `appdata/**/dynamic.yml`
+- **AND** the changed file is `appdata/traefik/dynamic.yml`
+- **THEN** the pattern matches the file
+- **AND** the changed file `appdata/traefik/other.yml` does NOT match
+
+#### Scenario: Leading recursive segment does not match everything
+
+- **WHEN** a hook pattern is `**/foo.yml`
+- **AND** the changed file is `unrelated/bar.yml`
+- **THEN** the pattern does NOT match
+- **AND** the changed file `nested/dir/foo.yml` DOES match
+
+#### Scenario: Deploy-path family uses the corrected matcher
+
+- **WHEN** `deploy_paths` contains `traefik/**/*.yml`
+- **AND** a commit changes only `traefik/conf.d/dynamic.yml`
+- **THEN** path-aware skip treats the deploy as relevant (the pattern matches the suffix, not just the `traefik/` prefix)
+- **AND** a commit changing only `docker-compose.yml` is NOT matched by that pattern
+
+### Requirement: FUSE-Safe Hook Timing
+
+The reconciler SHALL ensure written files are durably visible on the target filesystem before running post-sync hooks. It SHALL fsync each destination directory after renaming written files into place, and it SHALL apply a settle delay before executing hooks whose default value is a safe non-zero duration rather than zero.
+
+The settle delay SHALL be configurable via `hook_settle_delay` in `bosun.yaml` and the `BOSUN_HOOK_SETTLE_DELAY` environment variable. The `bosun doctor` preflight SHALL warn when a FUSE-like deploy target is configured with a zero settle delay, because hooks may then fire before the rename has propagated through FUSE caches.
+
+#### Scenario: Destination directory fsynced after write
+
+- **WHEN** the reconciler writes a config file to a deploy target and renames it into place
+- **THEN** the destination directory is fsynced before any post-sync hook runs
+
+#### Scenario: Default settle delay is non-zero
+
+- **WHEN** neither `hook_settle_delay` nor `BOSUN_HOOK_SETTLE_DELAY` is set
+- **THEN** the reconciler applies a safe non-zero settle delay before running hooks
+- **AND** the deploy does not fire hooks with a zero delay by default
+
+#### Scenario: Doctor warns on zero delay for FUSE target
+
+- **WHEN** `bosun doctor` runs against a FUSE-like deploy target (e.g. an Unraid `/mnt/user` path)
+- **AND** the effective `hook_settle_delay` is `0s`
+- **THEN** doctor emits a warning that hooks may fire before FUSE propagation completes
+
+#### Scenario: Explicit zero delay honored on non-FUSE target
+
+- **WHEN** an operator sets `BOSUN_HOOK_SETTLE_DELAY=0s`
+- **THEN** the reconciler applies no settle delay
+- **AND** no startup error is raised
+
+### Requirement: Hook Match Observability
+
+When post-sync hooks are configured and the reconciler evaluates a non-empty set of changed files but no file matches any hook pattern, the reconciler SHALL emit a warning that surfaces the misconfiguration. The warning SHALL name the configured patterns and a sample of the evaluated changed files, and SHALL distinguish "no files changed" from "files changed but no pattern matched", so a typo'd glob produces a discoverable signal rather than a silent no-op.
+
+#### Scenario: Typo'd pattern surfaces a warning
+
+- **WHEN** a hook is configured with paths `["traefik/**"]`
+- **AND** the deploy change set contains `appdata/traefik/dynamic.yml` (prefixed differently)
+- **THEN** the reconciler logs a warning naming the configured patterns and sample changed files
+- **AND** the warning indicates files changed but none matched
+
+#### Scenario: No-change deploy is not flagged as a mismatch
+
+- **WHEN** hooks are configured
+- **AND** the deploy change set is empty
+- **THEN** the reconciler does not emit a no-match warning (the "no files changed" case is logged distinctly, not as a misconfiguration)
+
+### Requirement: Post-Write Verification Propagation
+
+A successful file write whose post-write content verification fails SHALL NOT be silently omitted from the deploy change set. When `CopyFileIfChanged` renames a file into place successfully but the post-write hash readback fails — a known FUSE-staleness symptom — the reconciler SHALL either record the path in the change set so matching hooks still fire, or surface the verification failure as an error. It SHALL NOT return as if the file were unchanged, which would also cause the file to be skipped (and the hook to miss) on a later retry.
+
+#### Scenario: Verification failure still records the written path
+
+- **WHEN** a file is renamed into place successfully
+- **AND** the post-write content verification fails
+- **THEN** the path is recorded in the change set (hook-eligible) or the deploy surfaces an error
+- **AND** the file is NOT silently treated as unchanged
+
+#### Scenario: Retry after verification failure does not orphan the hook
+
+- **WHEN** a prior deploy left a file whose verification failed and which was not recorded
+- **AND** a subsequent deploy finds the on-disk content already matches the source hash
+- **THEN** the reconciler does not skip the file in a way that permanently prevents the hook from firing
+
+### Requirement: Hook Config Hot-Reload Removal Semantics
+
+On `bosun.yaml` hot-reload, the reconciler SHALL distinguish a `post_sync_hooks` or `hook_settle_delay` key that is absent from one that is explicitly set. An absent key SHALL retain the previously loaded in-memory value; it SHALL NOT silently reset the value to its zero. The reload DTO fields SHALL be pointer-typed so that an absent YAML key decodes to nil and is skipped by the reloader.
+
+To clear hooks, an operator SHALL set `post_sync_hooks: []`. To reset the settle delay to zero, an operator SHALL set `hook_settle_delay: 0s` explicitly.
+
+#### Scenario: Absent settle-delay key retains prior value
+
+- **WHEN** the daemon loaded `hook_settle_delay: 5s`
+- **AND** a later commit drops the `hook_settle_delay` line
+- **THEN** a hot-reload leaves the in-memory delay at `5s` (unchanged)
+
+#### Scenario: Explicit zero delay clears the value
+
+- **WHEN** a later commit sets `hook_settle_delay: 0s` explicitly
+- **THEN** a hot-reload sets the in-memory delay to zero
+
+#### Scenario: Absent hooks key retains prior hooks
+
+- **WHEN** the daemon loaded one or more `post_sync_hooks`
+- **AND** a later commit removes the `post_sync_hooks:` section entirely
+- **THEN** a hot-reload retains the previously loaded hooks (no silent clear)
+
+#### Scenario: Empty hooks list clears hooks
+
+- **WHEN** a later commit sets `post_sync_hooks: []`
+- **THEN** a hot-reload clears the in-memory hooks

--- a/openspec/changes/add-reconcile-fuse-hooks/specs/reconcile/spec.md
+++ b/openspec/changes/add-reconcile-fuse-hooks/specs/reconcile/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Post-Sync Container Restart Hooks
+
+The reconciler SHALL support configurable post-sync hooks that act on containers when specific file paths change during deployment, including paths that are deleted.
+
+Hooks SHALL be configured via `PostSyncHooks` with fields: `Paths` (glob patterns
+matched against changed files relative to repo root), `Action` (the action to
+perform, `restart` or `exec`), `Container` (the container name to act on), and
+`Command` (required for `exec`). A hook whose action is `exec` with an empty or
+absent `Command` SHALL be rejected as a config-load error, not silently skipped.
+
+After a successful deployment, the reconciler SHALL determine the set of changed
+files, match them against hook glob patterns, and execute matching actions. The
+changed-file set SHALL include files that were added or modified AND files that
+were deleted (e.g. by `removeStaleFiles`), so that a deletion-only commit still
+fires matching hooks. Each container SHALL be restarted at most once per
+deployment, even if multiple patterns match.
+
+Hooks SHALL only execute when a Docker client is available, dry run is false, hooks
+are configured, and a previous commit exists (not on first deploy).
+
+Glob patterns SHALL support `**` for recursive directory matching, honoring any
+literal suffix that follows the `**` segment.
+
+#### Scenario: Container restarted after config change
+
+- **WHEN** a hook is configured with paths `["traefik/conf.d/**"]` and container `traefik`
+- **AND** a deployment changes `traefik/conf.d/dynamic.yml`
+- **THEN** the reconciler restarts the `traefik` container after compose up
+- **AND** logs the hook execution
+
+#### Scenario: No restart when unrelated files change
+
+- **WHEN** a hook is configured with paths `["traefik/conf.d/**"]` and container `traefik`
+- **AND** a deployment only changes `docker-compose.yml`
+- **THEN** the reconciler does not restart the `traefik` container
+
+#### Scenario: Deletion-only commit fires the hook
+
+- **WHEN** a hook is configured with paths `["traefik/conf.d/**"]` and container `traefik`
+- **AND** a deployment only deletes `traefik/conf.d/legacy.yml` (no added or modified files)
+- **THEN** the deleted path is included in the changed-file set
+- **AND** the reconciler restarts the `traefik` container
+
+#### Scenario: Unsupported hook action skipped
+
+- **WHEN** a hook has an action other than `restart` or `exec`
+- **THEN** the hook is skipped with a warning log
+
+#### Scenario: Exec hook with empty command rejected at load
+
+- **WHEN** a hook is configured with `action: exec` and an empty or absent `command`
+- **THEN** config loading fails with an error identifying the invalid hook
+- **AND** the daemon does not run the deployment with the silently-skipped hook
+
+#### Scenario: First deploy skips hooks
+
+- **WHEN** there is no previous commit (first deployment)
+- **THEN** post-sync hooks are not evaluated

--- a/openspec/changes/add-reconcile-fuse-hooks/tasks.md
+++ b/openspec/changes/add-reconcile-fuse-hooks/tasks.md
@@ -1,0 +1,47 @@
+## 1. Glob matching correctness (#232)
+
+- [ ] 1.1 Replace `matchGlob` (`hooks.go:105-122`) prefix-only `**` handling with full doublestar semantics (suffix/infix honored, `**/foo` does not match unrelated files)
+- [ ] 1.2 Confirm `matchAnyPath` (`deploy.go`) uses the corrected matcher for `deploy_paths` / `deploy_sync_paths` / `deploy_sync_exclude`
+- [ ] 1.3 Tests: `matchGlob("**/foo.yml", "unrelated/bar.yml")==false`; `matchGlob("appdata/**/dynamic.yml", "appdata/traefik/dynamic.yml")==true`; deploy-path family regression cases
+
+## 2. FUSE-safe hook timing (#233)
+
+- [ ] 2.1 fsync the destination directory after rename in `fileutil.CopyFile` (`:60-110`)
+- [ ] 2.2 Change `HookSettleDelay` default from `0` to a safe non-zero value; apply the delay before running hooks in `hooks.go`
+- [ ] 2.3 Add a `doctor`/preflight check warning when a FUSE-like target runs with `hook_settle_delay: 0s`
+- [ ] 2.4 Tests: dir fsync invoked after write; non-zero default applied; doctor warns on zero-delay FUSE target
+
+## 3. Deletion-aware hooks (#234)
+
+- [ ] 3.1 Append `removeStaleFiles` deletions (`deploy.go:155-158`, `:251-299`) to the deploy change set (`WrittenFiles` or parallel `DeletedFiles`), tagged op=remove
+- [ ] 3.2 Ensure `executePostSyncHooks` (`reconcile.go:769-786`) evaluates the merged add+remove set (move empty-match return below the merge)
+- [ ] 3.3 Tests: deletion-only commit matching a hook pattern fires the hook
+
+## 4. Hook match observability (#269)
+
+- [ ] 4.1 In `executePostSyncHooks`, emit a warn-level log when hooks are configured and changed files were evaluated but nothing matched, naming patterns and sample files
+- [ ] 4.2 Distinguish "no files changed" from "files changed, none matched" in the log message
+- [ ] 4.3 Tests: typo'd pattern over a non-empty change set produces a discoverable warning
+
+## 5. Empty hook command rejection (#283)
+
+- [ ] 5.1 Validate at config load that an `exec` hook has a non-empty command; reject with a clear error
+- [ ] 5.2 Remove (or make unreachable) the silent warn-and-continue skip in `hooks.go:188-194`
+- [ ] 5.3 Tests: config with `action: exec` and empty/absent command fails to load
+
+## 6. Post-write verification propagation (#282)
+
+- [ ] 6.1 In `CopyFileIfChanged` (`fileutil.go:217-221`) / `deploy.go:314-321`, ensure a successful rename whose post-write verification fails still records the path in the change set (or surfaces a hard error) — never silently omits it
+- [ ] 6.2 Tests: simulated verification failure still results in the path being hook-eligible (not skipped on retry)
+
+## 7. Hot-reload removal semantics (#267 / #268)
+
+- [ ] 7.1 Make the reload DTO field for `hook_settle_delay` a `*time.Duration` (`config_reload.go:38-41`, `daemon.go:1621-1624`); reloader overwrites only when non-nil
+- [ ] 7.2 Make the reload DTO field for `post_sync_hooks` a `*[]PostSyncHook` (`config_reload.go:36`, `configfield.go:59-66`); absent key ⇒ nil ⇒ retained
+- [ ] 7.3 Tests: absent `hook_settle_delay` retains prior value; explicit `0s` zeroes it; absent `post_sync_hooks` retains hooks; `post_sync_hooks: []` clears them
+
+## 8. Documentation
+
+- [ ] 8.1 Update `skills/onboard/resources/gitops.md` (hook timing, FUSE, deletion-aware hooks, glob semantics)
+- [ ] 8.2 Update `docs/gitops.md` and `docs/troubleshooting.md`
+- [ ] 8.3 Update the `CLAUDE.md` env-var table (settle-delay default change, reload removal semantics)


### PR DESCRIPTION
## Summary

Spec-only proposal (Cluster D of the April 2026 reconcile-path bug hunt) hardening the post-deploy hook and FUSE-propagation semantics of the reconcile pipeline. These are the silent-failure modes that make a hook report success while never firing or never being seen by the target service on Unraid FUSE.

Adds a new `reconcile-fuse-hooks` capability (glob correctness, FUSE-safe timing, match observability, post-write verification propagation, hot-reload removal semantics) and **MODIFIES** the existing `reconcile` *Post-Sync Container Restart Hooks* requirement (deletion-aware change set, empty `exec` command rejection).

**Spec-only / Wave 1** — no Go code. Implementation is Wave 2, gated on `ready-to-build`.

## Findings → Requirements

| Issue | Severity | Requirement |
|-------|----------|-------------|
| #232 | P0 | Recursive Glob Matching Correctness (`**` suffix honored; `**/foo` not match-all; shared with `deploy_paths`) |
| #233 | P0 | FUSE-Safe Hook Timing (dir fsync + non-zero settle default + doctor warning) |
| #234 | P0 | Post-Sync Container Restart Hooks — *deletion-aware change set* (MODIFIED) |
| #269 | P1 | Hook Match Observability (typo'd glob warns) |
| #267 | P1 | Hook Config Hot-Reload Removal Semantics (`hook_settle_delay` absent ⇒ retained) |
| #268 | P1 | Hook Config Hot-Reload Removal Semantics (`post_sync_hooks` absent ⇒ retained) |
| #282 | P2 | Post-Write Verification Propagation (failed verify still hook-eligible) |
| #283 | P2 | Post-Sync Container Restart Hooks — *empty exec command rejected at load* (MODIFIED) |

`openspec validate add-reconcile-fuse-hooks --strict` → valid.

Refs bosun-bzz

## Test plan

- [ ] CodeRabbit reviews and converges (0 actionable / only stale)
- [ ] Fix all findings including nitpicks
- [ ] Label `ready-to-build` once stable (not applied yet)
- [ ] Implementation in Wave 2 against this spec