### PR TITLE
spec: add-backup-integrity-semantics — verified backups + propagated deploy errors (Cluster H)

### DIFF
--- a/openspec/changes/add-backup-integrity-semantics/design.md
+++ b/openspec/changes/add-backup-integrity-semantics/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The reconcile pipeline takes a configuration backup, then mutates the target
+(local copy or tar-over-SSH), then runs `docker compose up`, then gates on
+critical-container health. Backup, deploy, and rollback evolved independently and
+each has a fail-open seam: backup creation swallows transport errors and accepts
+truncated archives; retention runs before deploy verification; deploy-prep
+mkdir errors are discarded; the tar extract is only integrity-checked on a
+non-nil tar error; and the health-gate rollback reuses the deploy-or-rollback
+function, which re-runs the failing files. The net effect is a safety net that
+reports success while leaving prod broken or unrecoverable.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Fail closed before mutating target state when no usable backup exists.
+  - Surface the real root cause of pre-deploy failures to the operator.
+  - Guarantee a recoverable last-known-good through the deploy window.
+  - Make rollback restore the previous-good state, not re-apply the failing one.
+- Non-Goals:
+  - Reworking the backup archive format or switching tar-over-SSH to rsync
+    (mentioned in findings as an option; left to implementation choice).
+  - Orphan remote `tar`/temp-dir cleanup on context cancellation (#251, #276).
+  - Changing the SSH host-injection allowlist (shipped in Cluster A).
+
+## Decisions
+
+- **Decision: Reverse "backup failure is non-fatal" for backups that protect a
+  mutation.** The existing spec lets backup failure log a warning and continue;
+  this leaves the deploy with no rollback target. The new rule is fail-closed: a
+  required backup that cannot be created/verified aborts the reconcile before any
+  target mutation. The genuinely-nothing-to-back-up case is distinct — it records
+  "no backup available" rather than a failure, and downstream rollback skips.
+  - Alternative considered: keep continuing-on-warning but mark the deploy
+    "unrecoverable" — rejected; it preserves the silent-corruption window.
+
+- **Decision: Deep verification, not "non-empty + listable".** A truncated gzip
+  can still list. Verification must round-trip (extract to a scratch location or
+  validate the gzip trailer / file-count manifest) so a partial archive fails.
+
+- **Decision: Defer retention until after deploy verification.** Pruning the
+  prior last-known-good before the new deploy is proven destroys the only
+  recoverable baseline at `BackupsToKeep == 1`. Cleanup moves after verification.
+
+- **Decision: Distinct rollback path.** The health-gate failure case is
+  "deploy succeeded but is unhealthy", so re-running the new files is a no-op that
+  exits 0. Rollback must explicitly re-apply the backup compose files via a
+  dedicated path (mirroring the isolated rollback at `compose.go:325`).
+
+## Risks / Trade-offs
+
+- **Fail-closed backups can block a first deploy on a fresh host** → mitigated by
+  the explicit no-backup-available branch: nothing to back up is not a failure.
+- **Deferred retention can briefly exceed `BackupsToKeep`** → acceptable; the
+  extra backup is the safety margin and is pruned after verification.
+- **Deep verification adds I/O per backup** → bounded by archive size; backups
+  already stream the full tar, so the marginal cost is a single extract/list pass.
+
+## Migration Plan
+
+1. Operators relying on "backup failure continues anyway" must ensure the backup
+   target is writable; a failing backup now aborts the reconcile with a clear
+   cause. Fresh hosts with nothing to back up are unaffected.
+2. Rollback: revert the change — no persisted state format changes, so rollback
+   is code-only.
+
+## Open Questions
+
+- Verification mechanism: full extract to scratch vs gzip-trailer + file-count
+  manifest. Lean toward file-count parity to bound cost; settle in implementation.
+- Whether the "no backup available" state should additionally suppress the
+  health-gate rollback attempt entirely or merely no-op it (lean: no-op with a
+  clear log line).

--- a/openspec/changes/add-backup-integrity-semantics/design.md
+++ b/openspec/changes/add-backup-integrity-semantics/design.md
@@ -34,6 +34,21 @@ reports success while leaving prod broken or unrecoverable.
   - Alternative considered: keep continuing-on-warning but mark the deploy
     "unrecoverable" — rejected; it preserves the silent-corruption window.
 
+- **Decision: Build fail-closed on top of #319's bounded timeout, not in place of
+  it.** #319 (already merged) gave `Configuration Backup` a `BackupTimeout`
+  (`BOSUN_BACKUP_TIMEOUT`), context-bound verification, and a self-exclusion
+  invariant — the original "non-fatal" rule existed only to stop a hung backup
+  from wedging the reconcile. With the timeout in place a stuck backup now fails
+  fast and loud, so the wedge risk that motivated "non-fatal" is gone, and
+  aborting on a required-backup failure cannot hang the pipeline. Because an
+  OpenSpec `MODIFIED` requirement replaces the whole block on archive, this change
+  re-states all three #319 clauses verbatim so archiving does not silently revert
+  them, and correspondingly updates the `Pipeline Orchestration` stage-7 carve-out
+  from "non-fatal" to the conditional rule (nothing-to-back-up proceeds; a
+  required-backup failure aborts before state mutation).
+  - This resolves the merge-ordering hazard between #319 and this change: the two
+    no longer contradict, and #319's behavior survives the archive.
+
 - **Decision: Deep verification, not "non-empty + listable".** A truncated gzip
   can still list. Verification must round-trip (extract to a scratch location or
   validate the gzip trailer / file-count manifest) so a partial archive fails.

--- a/openspec/changes/add-backup-integrity-semantics/proposal.md
+++ b/openspec/changes/add-backup-integrity-semantics/proposal.md
@@ -71,11 +71,22 @@ target state**.
   rollback MUST re-apply the backed-up previous-good compose files and MUST NOT
   re-run the new (failing) file set; an idempotent `docker compose up` exit 0 on
   the failing files MUST NOT be treated as a successful rollback.
+- **Coordinated with #319 (already merged)** — #319 landed a bounded
+  `BackupTimeout` (`BOSUN_BACKUP_TIMEOUT`), context-bound verification, and a
+  backup self-exclusion invariant on the `Configuration Backup` requirement. This
+  change preserves all three clauses verbatim (so archiving does not revert them)
+  and is what makes fail-closed safe: a stuck backup now fails fast and loud
+  within the timeout rather than wedging the reconcile, so aborting on a required
+  backup failure cannot hang the pipeline. The stage-7 carve-out in
+  `Pipeline Orchestration` is updated from "backup failures are non-fatal" to the
+  conditional rule: nothing-to-back-up proceeds, a required-backup failure aborts
+  before state mutation.
 
 ## Impact
 
-- Affected specs: `reconcile` — MODIFIED `Configuration Backup` and
-  `File Deployment`; ADDED `Backup-Backed Rollback Integrity`.
+- Affected specs: `reconcile` — MODIFIED `Configuration Backup`,
+  `File Deployment`, and `Pipeline Orchestration`; ADDED
+  `Backup-Backed Rollback Integrity`.
 - Affected code:
   - `internal/reconcile/backup.go` — `Backup` (`:54-110`), `BackupRemote`
     discarded `sshErr` and `2>/dev/null` (`:150-184`), `VerifyBackup`,

--- a/openspec/changes/add-backup-integrity-semantics/proposal.md
+++ b/openspec/changes/add-backup-integrity-semantics/proposal.md
@@ -1,0 +1,94 @@
+# Change: Backup integrity and deploy error semantics (Cluster H)
+
+## Why
+
+The April 2026 reconcile-path bug hunt found that the backup-and-rollback safety
+net is fictional in several failure modes, and that pre-deploy errors are
+swallowed so the operator chases red herrings.
+
+The reconcile spec currently states "Backup failures SHALL log a warning but
+SHALL NOT abort the deployment pipeline" — but the implementation then deploys
+with no usable rollback target, and three concrete bugs make that worse:
+
+- `BackupRemote` discards the SSH error (`_ = sshErr`) and pipes remote `tar`
+  stderr to `/dev/null`. An auth failure, host-key rejection, or mid-stream
+  network drop still leaves a truncated-but-listable archive that passes
+  verification; a later rollback restores prod to a state that was never on disk
+  (#240, P0 silent corruption).
+- When no existing paths are present (fresh host or misconfigured appdata path),
+  `Backup` returns success without writing `configs.tar.gz`, sets
+  `lastBackupPath` to an empty directory, and skips verification. A subsequent
+  health-gate rollback then "restores" from a backup that never existed (#244).
+- `CleanupBackups` runs immediately after creating the new backup. With
+  `BackupsToKeep == 1` it deletes the prior cycle's last-known-good baseline
+  before the new deploy is verified — so a deploy that breaks past the health
+  gate leaves only a snapshot of the broken state (#243).
+- The tar-over-SSH deploy path checks integrity only when `tarErr != nil`. A tar
+  that exits 0 with an empty/partial archive passes, the move runs, and the
+  target directory is replaced with garbage (#252).
+- Every pre-deploy directory creation (`EnsureRemoteDir`, `MkdirAll`) uses
+  `_ = ...`. When mkdir fails (FUSE mount down, permission denied, SSH dropped),
+  the operator sees a confusing downstream "scp failed" / "file not found"
+  instead of the real cause (#250).
+- The health-gate rollback calls the deploy-or-rollback function with the NEW
+  (failing) compose files; because containers already exist, `docker compose up`
+  exits 0 and the function returns before ever consulting the backup. Bosun logs
+  "rollback attempted" while Docker still runs the broken release (#229, P0 —
+  the documented critical-container safety net does nothing).
+
+These are spec gaps: the `reconcile` capability has no error semantics for
+backup creation/verification, no ordering guarantee for retention versus deploy
+success, no archive-integrity guarantee for the deploy path, and no requirement
+that rollback restore the previous-good state rather than re-apply the failing
+one. This change tightens those requirements to **fail closed before mutating
+target state**.
+
+## What Changes
+
+- **Verified, fail-closed backups** — backup creation MUST be verified for deep
+  integrity (the archive lists AND extracts/round-trips, not merely "non-empty
+  and listable") before the deploy mutates target state. An unverifiable backup
+  MUST abort the reconcile rather than proceed with no safety net. **BREAKING**:
+  reverses the current "backup failure logs a warning and continues" behavior.
+- **Empty backup is not a rollback target** — when there is genuinely nothing to
+  back up, the reconciler MUST record "no backup available" (empty
+  `lastBackupPath`) so downstream rollback skips cleanly with a clear message
+  instead of failing opaquely against an empty directory.
+- **Surfaced remote backup errors** — remote backup MUST propagate the SSH/tar
+  error and MUST NOT suppress remote stderr; a transport-layer failure MUST fail
+  the backup loudly rather than producing a passing-but-truncated archive.
+- **Retention preserves the last-known-good** — backup pruning MUST NOT delete
+  the prior-cycle backup until the current deploy has passed verification, so a
+  `BackupsToKeep == 1` operator always retains a recoverable baseline through the
+  deploy window.
+- **Propagated deploy-prep errors** — directory-creation and remote-prep errors
+  (`EnsureRemoteDir`, `MkdirAll`) MUST propagate with their real cause wrapped to
+  name the failing layer, not be discarded.
+- **Deploy archive integrity** — the tar-over-SSH deploy path MUST verify the
+  extracted archive (e.g. file-count parity) before the atomic move; a partial
+  or empty archive MUST abort the deploy and preserve the existing target.
+- **Backup-backed rollback** — when a deploy fails or the health gate trips,
+  rollback MUST re-apply the backed-up previous-good compose files and MUST NOT
+  re-run the new (failing) file set; an idempotent `docker compose up` exit 0 on
+  the failing files MUST NOT be treated as a successful rollback.
+
+## Impact
+
+- Affected specs: `reconcile` — MODIFIED `Configuration Backup` and
+  `File Deployment`; ADDED `Backup-Backed Rollback Integrity`.
+- Affected code:
+  - `internal/reconcile/backup.go` — `Backup` (`:54-110`), `BackupRemote`
+    discarded `sshErr` and `2>/dev/null` (`:150-184`), `VerifyBackup`,
+    `CleanupBackups` (`:187-225`)
+  - `internal/reconcile/reconcile.go` — backup/cleanup ordering (`:1067-1085`),
+    swallowed `EnsureRemoteDir`/`MkdirAll` (`:1218`, `:1233`, `:1330`, `:1340`,
+    `:1351`), health-gate rollback (`:872-877`)
+  - `internal/reconcile/ssh.go` — tar-over-SSH extract/move integrity (`:224-262`)
+  - `internal/reconcile/compose.go` — `ComposeUpMultipleWithRollback`
+    (`:172-192`) vs the isolated rollback path (`:325`)
+- Findings addressed: #240, #243, #244, #250, #252, #229.
+- Out of scope (tracked elsewhere): #251 and #276 (orphan remote `tar`/temp-dir
+  cleanup on context cancellation) — pure subprocess-orphan cleanup, not backup
+  integrity. SSH option-injection hardening already shipped in Cluster A.
+- Docs: `skills/onboard/resources/gitops.md` (backup/rollback semantics),
+  `docs/troubleshooting.md`, `CLAUDE.md` reconcile-pipeline notes.

--- a/openspec/changes/add-backup-integrity-semantics/specs/reconcile/spec.md
+++ b/openspec/changes/add-backup-integrity-semantics/specs/reconcile/spec.md
@@ -4,9 +4,13 @@
 
 The reconciler SHALL create a timestamped tar.gz backup of existing configuration files before deploying new ones, and SHALL fail closed when a required backup cannot be created or verified. Backups SHALL be named `backup-YYYYMMDD-HHMMSS`.
 
-The reconciler SHALL verify backup integrity after creation by deep inspection — the archive SHALL list AND round-trip (extract or file-count parity), not merely be non-empty and listable. A truncated, empty, or corrupted archive SHALL cause the backup to fail. Backup verification SHALL NOT be skipped on any path that produced an archive.
+The reconciler SHALL verify backup integrity after creation by deep inspection — the archive SHALL list AND round-trip (extract or file-count parity), not merely be non-empty and listable. A truncated, empty, or corrupted archive SHALL cause the backup to fail. Backup verification SHALL NOT be skipped on any path that produced an archive. Verification SHALL run under the same cancellation context as creation, so a caller deadline or cancellation aborts verification rather than blocking indefinitely.
 
 When the backup spans an active transport (remote tar-over-SSH), the reconciler SHALL propagate the transport error and SHALL NOT suppress the remote command's stderr. A transport-layer failure SHALL fail the backup loudly rather than producing a passing-but-truncated archive.
+
+The backup archive SHALL NOT include the backup destination directory or any prior backup it contains. When the configured backup destination is nested within a backed-up path (for example, the reconciler's own appdata directory), the reconciler SHALL exclude the destination so the archive cannot recursively include its own growing output.
+
+Backup creation and verification SHALL run under a configurable timeout (`BackupTimeout`, default 5 minutes, overridable via `BOSUN_BACKUP_TIMEOUT` accepting a Go duration or a plain number of seconds). When the timeout elapses, the backup SHALL be treated as a failure. For a required backup this aborts the reconcile under the fail-closed rule below; a cold-state reconcile with nothing to back up never starts a backup and is therefore unaffected.
 
 When a required backup cannot be created or verified, the reconciler SHALL abort the reconcile before mutating target state, rather than proceeding with no rollback target.
 
@@ -99,6 +103,64 @@ All remote operations SHALL validate the host string against an allowlist patter
 - **WHEN** the tar-over-SSH extraction produces an empty or partial archive even though the tar command exits 0
 - **THEN** the extracted-file integrity check fails before the atomic move
 - **AND** the existing target directory is preserved unchanged
+
+### Requirement: Pipeline Orchestration
+
+The reconciler SHALL execute stages in this fixed order:
+
+1. Acquire lock
+2. Git repository sync
+3. Load deploy state and evaluate skip/circuit-breaker logic
+4. Decrypt secrets (SOPS)
+5. Render templates (Go text/template + Sprig)
+6. Extract declared state from rendered compose
+7. Create configuration backup
+8. Deploy files (local or remote)
+9. Run `docker compose up`
+10. Clean up staging directory
+11. Critical container health gate (if configured)
+12. Execute post-sync hooks
+13. Post-deploy verification (drift check)
+14. Record successful deployment in state file
+15. Release lock
+
+A failure at any stage SHALL abort the remaining stages and release the lock. Configuration backup (stage 7) is the sole conditional case: when there is genuinely nothing to back up (no existing configuration paths), the empty result is recorded and the pipeline proceeds; but when a required backup cannot be created or verified — including on timeout — the reconciler SHALL abort before mutating target state (stage 8 onward), consistent with the fail-closed Configuration Backup requirement. The health gate (stage 11) failing SHALL trigger rollback before aborting.
+The lock SHALL always be released via defer, even on panic.
+
+#### Scenario: Full pipeline succeeds
+
+- **WHEN** a reconciliation is triggered and a new commit is available
+- **THEN** all stages execute in order
+- **AND** the deploy state file records the deployed commit
+- **AND** a success alert is sent
+
+#### Scenario: Pipeline aborts on stage failure
+
+- **WHEN** secret decryption fails
+- **THEN** template rendering, backup, deploy, and compose stages are skipped
+- **AND** a throttled failure alert is sent
+- **AND** the lock is released
+
+#### Scenario: Required backup failure aborts before deploy
+
+- **WHEN** a required backup (existing config paths present) cannot be created or verified, including on timeout
+- **THEN** stages 8 onward (deploy, compose up) are skipped
+- **AND** no target file is written and the existing state is left intact
+- **AND** the lock is released
+
+#### Scenario: Dry run mode
+
+- **WHEN** `DryRun` is true
+- **THEN** backup, deploy, compose up, health gate, post-sync hooks, and post-deploy verification are skipped
+- **AND** template rendering still executes to validate templates
+
+#### Scenario: Health gate failure triggers rollback
+
+- **WHEN** compose up succeeds but a critical container fails the health gate
+- **THEN** the reconciler triggers rollback to the backup compose files
+- **AND** the deployment is NOT recorded as successful
+- **AND** a failure alert is sent
+- **AND** the lock is released
 
 ## ADDED Requirements
 

--- a/openspec/changes/add-backup-integrity-semantics/specs/reconcile/spec.md
+++ b/openspec/changes/add-backup-integrity-semantics/specs/reconcile/spec.md
@@ -1,0 +1,129 @@
+## MODIFIED Requirements
+
+### Requirement: Configuration Backup
+
+The reconciler SHALL create a timestamped tar.gz backup of existing configuration files before deploying new ones, and SHALL fail closed when a required backup cannot be created or verified. Backups SHALL be named `backup-YYYYMMDD-HHMMSS`.
+
+The reconciler SHALL verify backup integrity after creation by deep inspection — the archive SHALL list AND round-trip (extract or file-count parity), not merely be non-empty and listable. A truncated, empty, or corrupted archive SHALL cause the backup to fail. Backup verification SHALL NOT be skipped on any path that produced an archive.
+
+When the backup spans an active transport (remote tar-over-SSH), the reconciler SHALL propagate the transport error and SHALL NOT suppress the remote command's stderr. A transport-layer failure SHALL fail the backup loudly rather than producing a passing-but-truncated archive.
+
+When a required backup cannot be created or verified, the reconciler SHALL abort the reconcile before mutating target state, rather than proceeding with no rollback target.
+
+When there is genuinely nothing to back up (no existing configuration paths present), the reconciler SHALL record that no backup is available by leaving the last backup path empty, rather than recording an empty directory as a successful backup.
+
+Old backups SHALL be pruned to retain only the most recent N backups (configurable via `BackupsToKeep`, default 5). Pruning SHALL NOT delete the prior-cycle backup until the current deploy has passed verification, so the previous last-known-good baseline survives through the deploy window.
+
+The last backup path SHALL be stored for potential rollback during compose up. An empty last backup path SHALL signal "no backup available" to downstream rollback.
+
+#### Scenario: Local backup created and verified
+
+- **WHEN** a local deployment runs with existing config files
+- **THEN** a timestamped tar.gz is created containing the config paths
+- **AND** the archive is verified by deep inspection (lists and round-trips), not merely non-empty
+
+#### Scenario: Remote backup propagates transport failure
+
+- **WHEN** a remote backup's SSH session fails (auth rejection, host-key mismatch, or mid-stream network drop)
+- **THEN** the remote command's stderr is surfaced, not discarded
+- **AND** the backup fails with the transport error rather than reporting success on a truncated archive
+
+#### Scenario: Truncated archive fails verification
+
+- **WHEN** a backup archive is produced but is truncated or partial
+- **THEN** deep verification detects the corruption
+- **AND** the backup is reported as failed
+
+#### Scenario: Unverifiable backup aborts the reconcile
+
+- **WHEN** a required backup cannot be created or cannot be verified
+- **THEN** the reconcile aborts before any target file is written or compose up runs
+- **AND** an error names the backup failure as the cause
+
+#### Scenario: Nothing to back up yields no rollback target
+
+- **WHEN** no existing configuration paths are present (fresh host or empty appdata path)
+- **THEN** the reconciler records that no backup is available with an empty last backup path
+- **AND** a later rollback skips cleanly with a "no backup available" message instead of failing against an empty directory
+
+#### Scenario: Retention preserves last-known-good through deploy
+
+- **WHEN** `BackupsToKeep` is 1 and a new backup is created at the start of a deploy cycle
+- **THEN** the prior-cycle backup is retained until the current deploy passes verification
+- **AND** pruning to the configured count occurs only after successful verification
+
+### Requirement: File Deployment
+
+The reconciler SHALL support two deployment modes: local (direct file operations) and remote (SSH+tar or SCP), and SHALL propagate directory-preparation errors with their real cause rather than discarding them.
+
+Local deployment SHALL use atomic-like operations: copy source to a temp directory in the same parent, then rename to the target path. This provides atomic directory replacement with `--delete` semantics (files in target not in source are removed).
+
+Remote deployment SHALL use tar-over-SSH for directories (tar source, pipe to SSH for extraction in a temp dir, atomic move to target) and SCP for individual files (SCP to temp file, then atomic move).
+
+Pre-deploy directory creation (local `MkdirAll` and remote `EnsureRemoteDir`) SHALL propagate failures, wrapped to name the failing path and layer. Such errors SHALL NOT be discarded, so a downstream copy/scp failure never masks an mkdir or mount failure as the apparent cause.
+
+The tar-over-SSH deployment SHALL verify the extracted archive (e.g. file-count parity between the local source and the remote extraction) before performing the atomic move. A partial or empty archive — even when the tar command exits 0 — SHALL abort the deploy and SHALL preserve the existing target directory.
+
+All remote operations SHALL retry on transient SSH errors (connection refused, timeout, network unreachable) with exponential backoff (1s, 2s, 4s, max 3 attempts).
+
+All remote operations SHALL validate the host string against an allowlist pattern and reject strings starting with `-` to prevent SSH option injection.
+
+#### Scenario: Local atomic-like directory deployment
+
+- **WHEN** deploying a directory locally
+- **THEN** files are copied to a temp directory in the target's parent
+- **AND** the old target is renamed aside (e.g., `target.old`)
+- **AND** the temp directory is renamed to the target path
+- **AND** the aside directory is removed after successful rename
+- **AND** if the final rename fails, the aside directory is renamed back to restore the previous state
+
+#### Scenario: Remote deployment with SSH retry
+
+- **WHEN** a remote SSH operation fails with "connection refused"
+- **THEN** it retries up to 3 times with exponential backoff
+- **AND** succeeds on a subsequent attempt
+
+#### Scenario: SSH host validation rejects injection
+
+- **WHEN** a target host contains shell metacharacters or starts with `-`
+- **THEN** the operation fails with a validation error before any SSH command runs
+
+#### Scenario: Directory-prep failure surfaces the real cause
+
+- **WHEN** a pre-deploy `MkdirAll` or `EnsureRemoteDir` fails (FUSE mount down, permission denied, SSH dropped)
+- **THEN** the deploy fails with an error that names the failing path and the underlying cause
+- **AND** the error is not masked by a confusing downstream "file not found" or "scp failed"
+
+#### Scenario: Partial extracted archive aborts the deploy
+
+- **WHEN** the tar-over-SSH extraction produces an empty or partial archive even though the tar command exits 0
+- **THEN** the extracted-file integrity check fails before the atomic move
+- **AND** the existing target directory is preserved unchanged
+
+## ADDED Requirements
+
+### Requirement: Backup-Backed Rollback Integrity
+
+Rollback SHALL re-apply the backed-up previous-good compose files and SHALL NOT re-run the new (failing) compose file set. When a deploy fails or the critical-container health gate trips, the reconciler SHALL restore service state from the backup, not redeploy the release that just failed.
+
+An idempotent `docker compose up` that exits 0 against the failing files (because the unhealthy containers already exist) SHALL NOT be treated as a successful rollback. Rollback success SHALL be determined by re-applying the previous-good files, and the reconciler's logs and result status SHALL reflect the actual rollback outcome rather than a misleading "rollback attempted".
+
+When no backup is available (empty last backup path), the reconciler SHALL NOT attempt a backup-based rollback and SHALL log that no rollback target exists.
+
+#### Scenario: Health-gate failure restores previous-good files
+
+- **WHEN** compose up exits 0 but a critical container fails the health gate
+- **THEN** rollback re-applies the backed-up previous-good compose files
+- **AND** the failing new file set is not re-run as the rollback action
+
+#### Scenario: Idempotent re-up is not counted as rollback success
+
+- **WHEN** a rollback would re-run the new files and `docker compose up` exits 0 because the unhealthy containers already exist
+- **THEN** the reconciler does not report this as a successful rollback
+- **AND** the result status reflects that the previous-good state was restored or that rollback failed
+
+#### Scenario: No backup available skips rollback cleanly
+
+- **WHEN** a deploy fails and the last backup path is empty
+- **THEN** the reconciler logs that no rollback target is available
+- **AND** does not attempt to restore from an empty or missing backup

--- a/openspec/changes/add-backup-integrity-semantics/tasks.md
+++ b/openspec/changes/add-backup-integrity-semantics/tasks.md
@@ -1,0 +1,34 @@
+## 1. Verified, fail-closed backups (#240, #244)
+
+- [ ] 1.1 Strengthen `VerifyBackup` to confirm deep integrity (archive lists AND extracts/round-trips), not merely non-empty + `tar -tzf` exit 0
+- [ ] 1.2 In `BackupRemote`, stop discarding `sshErr` and stop piping remote `tar` stderr to `/dev/null`; return the transport error
+- [ ] 1.3 Make backup failure fail-closed: abort the reconcile before any target mutation when a required backup cannot be created/verified
+- [ ] 1.4 When there is genuinely nothing to back up, return `lastBackupPath == ""` (no empty directory) so rollback skips with a clear "no backup available" message
+- [ ] 1.5 Tests: SSH failure mid-stream fails the backup; truncated archive fails verification; empty-paths host yields no rollback target and a clean skip
+
+## 2. Retention preserves last-known-good (#243)
+
+- [ ] 2.1 Defer `CleanupBackups` until after the current deploy passes verification (or keep N+1 internally through the deploy window)
+- [ ] 2.2 Tests: with `backups_to_keep == 1`, the cycle T-1 backup survives through cycle T's deploy
+
+## 3. Propagated deploy-prep errors (#250)
+
+- [ ] 3.1 Propagate `EnsureRemoteDir` and `MkdirAll` errors at `reconcile.go:1218,1233,1330,1340,1351`, wrapped to name the failing path/layer
+- [ ] 3.2 Tests: with the target path unwritable, the error message includes the path and the underlying cause (e.g. "permission denied")
+
+## 4. Deploy archive integrity (#252)
+
+- [ ] 4.1 In the tar-over-SSH path (`ssh.go:224-262`), verify the extracted archive (e.g. file-count parity) before the atomic move; run cleanup on integrity failure, not only on `tarErr != nil`
+- [ ] 4.2 Tests: a simulated partial/empty archive aborts the move and preserves the existing target
+
+## 5. Backup-backed rollback (#229)
+
+- [ ] 5.1 Route the health-gate / deploy-failure rollback through a distinct path that re-applies the backed-up previous-good compose files, not `ComposeUpMultipleWithRollback` over the new files
+- [ ] 5.2 Ensure an idempotent `docker compose up` exit 0 on the failing files is not treated as a successful rollback
+- [ ] 5.3 Tests: a critical-container health failure re-deploys the previous-good files from backup; logs reflect actual rollback outcome
+
+## 6. Documentation
+
+- [ ] 6.1 Update `skills/onboard/resources/gitops.md` with backup/rollback fail-closed semantics
+- [ ] 6.2 Update `docs/troubleshooting.md` (backup-failure abort, no-backup-available skip)
+- [ ] 6.3 Update `CLAUDE.md` reconcile-pipeline notes if backup ordering changes

--- a/openspec/changes/add-backup-integrity-semantics/tasks.md
+++ b/openspec/changes/add-backup-integrity-semantics/tasks.md
@@ -5,6 +5,7 @@
 - [ ] 1.3 Make backup failure fail-closed: abort the reconcile before any target mutation when a required backup cannot be created/verified
 - [ ] 1.4 When there is genuinely nothing to back up, return `lastBackupPath == ""` (no empty directory) so rollback skips with a clear "no backup available" message
 - [ ] 1.5 Tests: SSH failure mid-stream fails the backup; truncated archive fails verification; empty-paths host yields no rollback target and a clean skip
+- [ ] 1.6 Preserve #319's already-merged behavior when reworking backup: keep `BackupTimeout`/`BOSUN_BACKUP_TIMEOUT`, context-bound verification, and the backup self-exclusion; route a timed-out *required* backup through the new fail-closed abort (not warn+continue), while a cold-state reconcile with nothing to back up is unaffected
 
 ## 2. Retention preserves last-known-good (#243)
 


### PR DESCRIPTION
## Summary

Spec-only change proposal (Wave 1, no implementation) tightening the
`reconcile` capability's **backup integrity and deploy error semantics**. The
April 2026 reconcile bug hunt found the backup-and-rollback safety net is
fictional in several failure modes and that pre-deploy errors are swallowed.

The current spec says "Backup failures SHALL log a warning but SHALL NOT abort
the deployment pipeline" — this change reverses that for backups that protect a
mutation, making the pipeline **fail closed before mutating target state**.

## Findings addressed

| # | Title | Delta |
|---|-------|-------|
| #240 | BackupRemote swallows SSH/tar errors — stale archive passes verification (P0) | MODIFIED Configuration Backup |
| #244 | lastBackupPath set to empty dir; VerifyBackup skipped | MODIFIED Configuration Backup |
| #243 | retention deletes previous good backup before deploy succeeds (N=1 loses LKG) | MODIFIED Configuration Backup |
| #250 | swallowed EnsureRemoteDir / MkdirAll errors mask the real cause | MODIFIED File Deployment |
| #252 | tar partial-extraction with local exit 0 replaces target dir with garbage | MODIFIED File Deployment |
| #229 | health-gate "rollback" silently re-runs broken deploy instead of restoring backup (P0) | ADDED Backup-Backed Rollback Integrity |

**Excluded** (tracked elsewhere): #251 / #276 (orphan remote `tar` / temp-dir
cleanup on context cancellation — pure subprocess-orphan cleanup, not backup
integrity). SSH option-injection hardening already shipped in Cluster A.

## Spec deltas (`openspec/changes/add-backup-integrity-semantics/`)

- **MODIFIED** `Configuration Backup` — deep verification, fail-closed on
  unverifiable backup, surfaced remote transport errors, empty-backup → no
  rollback target, retention deferred until after deploy verification.
- **MODIFIED** `File Deployment` — propagate `EnsureRemoteDir`/`MkdirAll` errors
  with real cause; verify extracted tar (file-count parity) before atomic move.
- **ADDED** `Backup-Backed Rollback Integrity` — rollback re-applies previous-good
  files, never re-runs the failing set; idempotent exit-0 is not rollback success.

`openspec validate add-backup-integrity-semantics --strict` → valid (3 deltas).

Refs bosun-8s5

## Test plan

- [ ] CodeRabbit review converges (0 actionable / only stale)
- [ ] Spec validates strict on every push
- [ ] Implementation (separate PR after `ready-to-build`): SSH-failure-mid-stream fails backup; truncated archive fails verification; empty-paths host yields clean rollback skip; `backups_to_keep=1` retains T-1 through T; unwritable target surfaces real mkdir cause; partial extracted archive preserves target; critical-container health failure re-deploys previous-good from backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)