### PR TITLE
spec: fold Cluster C target-safety into add-multi-target-reconcile

### DIFF
--- a/openspec/changes/add-multi-target-reconcile/proposal.md
+++ b/openspec/changes/add-multi-target-reconcile/proposal.md
@@ -15,6 +15,7 @@ Bosun's design principle is "one yacht, many ports" — a single monorepo can de
 - **Per-target alerting context** — alerts include the target name so operators know which server is affected
 - **Config file schema** — `bosun.yaml` gains an optional `targets:` section; when absent, behavior is identical to today
 - **Env var mapping** — `BOSUN_TARGETS` (JSON) defines targets; individual `BOSUN_TARGET_<NAME>_*` vars override per-target fields
+- **Target validation and safety** (folded from the Cluster C bug hunt) — target descriptors are validated at config-load for path traversal, colliding state/lock/staging paths, colliding Docker namespaces, case-insensitive reserved `default`, and YAML/env field parity; per-target configs deep-copy all slice/map fields on derivation and hot-reload; empty-field inheritance is explicit so a dev target cannot silently inherit a production host (GHSA-jxw8, GHSA-57r2, #228, #260, #270, #271, #272, #273, #287)
 
 ## Impact
 

--- a/openspec/changes/add-multi-target-reconcile/specs/reconcile/spec.md
+++ b/openspec/changes/add-multi-target-reconcile/specs/reconcile/spec.md
@@ -178,24 +178,29 @@ Overridden keys SHALL be logged at debug level to aid troubleshooting.
 The set of per-target fields settable via `BOSUN_TARGETS` SHALL be identical to the set settable via the `targets:` YAML section; neither source SHALL expose a field the other cannot set. An empty `BOSUN_TARGETS` value (`[]`) SHALL be treated identically to an absent `targets:` section (implicit `default` target).
 
 #### Scenario: Path traversal in target paths is rejected
+
 - **WHEN** a target sets `state_file`, `staging_dir`, or an appdata path containing `..` or escaping its permitted root, via either `bosun.yaml` or `BOSUN_TARGETS`
 - **THEN** the configuration is rejected at config-load with a path-validation error
 - **AND** no reconcile runs for any target
 
 #### Scenario: Reserved name matched case-insensitively
+
 - **WHEN** a user-defined target is named `Default` or `DEFAULT`
 - **THEN** it is rejected as using the reserved name, the same as lowercase `default`
 
 #### Scenario: Colliding state files are rejected
+
 - **WHEN** two targets resolve to the same explicit `state_file` path
 - **THEN** the configuration is rejected at config-load
 - **AND** the error names both colliding targets
 
 #### Scenario: Colliding Docker namespace is rejected
+
 - **WHEN** two distinct targets resolve to the same host and project name (and thus the same compose namespace and staging directory)
 - **THEN** the configuration is rejected or fails fast at config-load, rather than letting one target tear down the other's containers
 
 #### Scenario: YAML and env field parity
+
 - **WHEN** a per-target field (e.g. `state_file`, `staging_dir`) is settable via `BOSUN_TARGETS`
 - **THEN** the same field is settable via the `targets:` YAML section
 - **AND** an empty `BOSUN_TARGETS` (`[]`) yields the same implicit `default` target as an absent `targets:` section
@@ -205,14 +210,17 @@ The set of per-target fields settable via `BOSUN_TARGETS` SHALL be identical to 
 `ConfigForTarget` and hot-reload (`applyTargetOverrides`) SHALL produce per-target configurations that share no mutable backing storage. Every slice and map field on the per-target `Config` — including `SecretsFiles`, `DeployPaths`, `DriftIgnore`, `PostSyncHooks`, and `CriticalContainers` — SHALL be deep-copied, so that mutating one target's configuration never alters another target's or the base configuration. Empty per-target fields SHALL follow explicit, documented inheritance rules; an empty override SHALL NOT silently inherit a base value in a way that causes a target to deploy to an unintended host or path.
 
 #### Scenario: Mutating a per-target slice does not affect siblings
+
 - **WHEN** one target's `DeployPaths`, `SecretsFiles`, `DriftIgnore`, or `PostSyncHooks` slice is mutated after `ConfigForTarget`
 - **THEN** the base configuration and every other target's configuration are unchanged
 
 #### Scenario: Hot-reload preserves per-target independence
+
 - **WHEN** `bosun.yaml` is hot-reloaded during a multi-target cycle and `applyTargetOverrides` assigns per-target slices
 - **THEN** mutating one target's reloaded slice leaves sibling targets' slices unchanged
 
 #### Scenario: Empty override does not silently inherit a different host
+
 - **WHEN** a target leaves `target_host` empty
 - **THEN** inheritance follows the documented rule (empty means local, not "inherit the base/another target's host")
 - **AND** a dev target cannot accidentally resolve to a production host through silent inheritance

--- a/openspec/changes/add-multi-target-reconcile/specs/reconcile/spec.md
+++ b/openspec/changes/add-multi-target-reconcile/specs/reconcile/spec.md
@@ -171,6 +171,52 @@ Overridden keys SHALL be logged at debug level to aid troubleshooting.
 - **THEN** all targets receive the same secrets
 - **AND** behavior is identical to pre-multi-target versions
 
+### Requirement: Target Configuration Validation
+
+`ResolveTargets` SHALL validate every target descriptor at config-load time and reject the configuration when a target is unsafe, regardless of whether targets came from `bosun.yaml` or `BOSUN_TARGETS`. Validation SHALL cover: path safety (state file, lock file, staging directory, and appdata paths SHALL reject path traversal and SHALL be confined to their permitted roots), reserved-name handling (the reserved name `default` SHALL be matched case-insensitively, consistent with case-insensitive duplicate-name detection), and resource-collision detection (no two targets SHALL resolve to the same state file, lock file, or staging directory, nor to the same Docker namespace — identical host plus project name — or deploy path).
+
+The set of per-target fields settable via `BOSUN_TARGETS` SHALL be identical to the set settable via the `targets:` YAML section; neither source SHALL expose a field the other cannot set. An empty `BOSUN_TARGETS` value (`[]`) SHALL be treated identically to an absent `targets:` section (implicit `default` target).
+
+#### Scenario: Path traversal in target paths is rejected
+- **WHEN** a target sets `state_file`, `staging_dir`, or an appdata path containing `..` or escaping its permitted root, via either `bosun.yaml` or `BOSUN_TARGETS`
+- **THEN** the configuration is rejected at config-load with a path-validation error
+- **AND** no reconcile runs for any target
+
+#### Scenario: Reserved name matched case-insensitively
+- **WHEN** a user-defined target is named `Default` or `DEFAULT`
+- **THEN** it is rejected as using the reserved name, the same as lowercase `default`
+
+#### Scenario: Colliding state files are rejected
+- **WHEN** two targets resolve to the same explicit `state_file` path
+- **THEN** the configuration is rejected at config-load
+- **AND** the error names both colliding targets
+
+#### Scenario: Colliding Docker namespace is rejected
+- **WHEN** two distinct targets resolve to the same host and project name (and thus the same compose namespace and staging directory)
+- **THEN** the configuration is rejected or fails fast at config-load, rather than letting one target tear down the other's containers
+
+#### Scenario: YAML and env field parity
+- **WHEN** a per-target field (e.g. `state_file`, `staging_dir`) is settable via `BOSUN_TARGETS`
+- **THEN** the same field is settable via the `targets:` YAML section
+- **AND** an empty `BOSUN_TARGETS` (`[]`) yields the same implicit `default` target as an absent `targets:` section
+
+### Requirement: Per-Target Configuration Independence
+
+`ConfigForTarget` and hot-reload (`applyTargetOverrides`) SHALL produce per-target configurations that share no mutable backing storage. Every slice and map field on the per-target `Config` — including `SecretsFiles`, `DeployPaths`, `DriftIgnore`, `PostSyncHooks`, and `CriticalContainers` — SHALL be deep-copied, so that mutating one target's configuration never alters another target's or the base configuration. Empty per-target fields SHALL follow explicit, documented inheritance rules; an empty override SHALL NOT silently inherit a base value in a way that causes a target to deploy to an unintended host or path.
+
+#### Scenario: Mutating a per-target slice does not affect siblings
+- **WHEN** one target's `DeployPaths`, `SecretsFiles`, `DriftIgnore`, or `PostSyncHooks` slice is mutated after `ConfigForTarget`
+- **THEN** the base configuration and every other target's configuration are unchanged
+
+#### Scenario: Hot-reload preserves per-target independence
+- **WHEN** `bosun.yaml` is hot-reloaded during a multi-target cycle and `applyTargetOverrides` assigns per-target slices
+- **THEN** mutating one target's reloaded slice leaves sibling targets' slices unchanged
+
+#### Scenario: Empty override does not silently inherit a different host
+- **WHEN** a target leaves `target_host` empty
+- **THEN** inheritance follows the documented rule (empty means local, not "inherit the base/another target's host")
+- **AND** a dev target cannot accidentally resolve to a production host through silent inheritance
+
 ## MODIFIED Requirements
 
 ### Requirement: Pipeline Orchestration

--- a/openspec/changes/add-multi-target-reconcile/tasks.md
+++ b/openspec/changes/add-multi-target-reconcile/tasks.md
@@ -63,6 +63,7 @@
 - [ ] 8.4 Add multi-target example to `docs/` or README
 
 ## 9. Target validation and safety (folded from Cluster C bug hunt)
+
 - [ ] 9.1 `ResolveTargets` validates target-derived paths (state_file, lock_file, staging_dir, appdata) for traversal/root-confinement — same checks for YAML and `BOSUN_TARGETS` (GHSA-57r2)
 - [ ] 9.2 Reserved-name `default` check is case-insensitive, matching dedup (#228)
 - [ ] 9.3 Reject colliding state_file / lock_file / staging_dir across targets (#260)

--- a/openspec/changes/add-multi-target-reconcile/tasks.md
+++ b/openspec/changes/add-multi-target-reconcile/tasks.md
@@ -61,3 +61,14 @@
 - [ ] 8.2 Update `skills/onboard/resources/gitops.md` with multi-target workflow
 - [ ] 8.3 Update `skills/onboard/resources/configuration.md` with `targets:` schema
 - [ ] 8.4 Add multi-target example to `docs/` or README
+
+## 9. Target validation and safety (folded from Cluster C bug hunt)
+- [ ] 9.1 `ResolveTargets` validates target-derived paths (state_file, lock_file, staging_dir, appdata) for traversal/root-confinement — same checks for YAML and `BOSUN_TARGETS` (GHSA-57r2)
+- [ ] 9.2 Reserved-name `default` check is case-insensitive, matching dedup (#228)
+- [ ] 9.3 Reject colliding state_file / lock_file / staging_dir across targets (#260)
+- [ ] 9.4 Reject/fail-fast on colliding Docker namespace (host+project_name) or deploy path across targets (#287)
+- [ ] 9.5 YAML and `BOSUN_TARGETS` expose identical per-target field sets; `BOSUN_TARGETS=[]` == absent targets (#272, #273)
+- [ ] 9.6 `ConfigForTarget` deep-copies ALL slice/map fields incl. SecretsFiles, DeployPaths, DriftIgnore (#270)
+- [ ] 9.7 `applyTargetOverrides` deep-copies caller-owned slices on hot-reload (#271)
+- [ ] 9.8 Explicit, documented empty-field inheritance; empty override never silently inherits a foreign host/path (GHSA-jxw8)
+- [ ] 9.9 Tests: path-traversal rejection, collision rejection, slice independence after derive + hot-reload, field parity


### PR DESCRIPTION
## Summary

Folds the **Cluster C** bug-hunt findings into the in-flight `add-multi-target-reconcile` proposal (per the locked plan decision), rather than authoring a competing multi-target spec. Adds two ADDED requirements to the reconcile delta plus tasks (section 9) and a proposal bullet. Spec-only; Wave 1.

| Finding | Requirement |
|---|---|
| GHSA-57r2 (BOSUN_TARGETS state_file/staging_dir bypass path validation) | Target Configuration Validation — path safety |
| #228 (case-sensitive `default` vs case-insensitive dedup) | Target Configuration Validation — reserved name |
| #260 (StateFile collision undetected) | Target Configuration Validation — collision detection |
| #287 (path/host/namespace collision undetected) | Target Configuration Validation — collision detection |
| #272 / #273 (YAML vs BOSUN_TARGETS field asymmetry, empty `[]` handling) | Target Configuration Validation — field parity |
| #270 (SecretsFiles/DeployPaths/DriftIgnore not deep-copied) | Per-Target Configuration Independence |
| #271 (hot-reload stores caller-owned slices) | Per-Target Configuration Independence |
| GHSA-jxw8 (empty-field inherit dev→prod) | Per-Target Configuration Independence — inheritance safety |

`openspec validate add-multi-target-reconcile --strict` passes.

## Note for reviewers

This **edits a pending proposal** (`add-multi-target-reconcile`, 0/40 tasks) rather than creating a new change-id. If you'd rather these land as a standalone proposal, say so and I'll re-cut. The new requirements are additive (ADDED) and don't modify the proposal's existing requirements.

## Test plan

- [ ] CodeRabbit converges
- [ ] Label `ready-to-build` (note: gates the whole multi-target proposal — coordinate with its overall readiness)
- [ ] Implementation: Wave 2, Cluster C (last in daemon.go merge order)

Refs bosun-hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)