### PR TITLE
spec: add-backup-deadline-and-self-exclusion — bound the pre-deploy backup (#319)

### DIFF
--- a/openspec/changes/add-backup-deadline-and-self-exclusion/design.md
+++ b/openspec/changes/add-backup-deadline-and-self-exclusion/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The pre-deploy backup (`internal/reconcile/backup.go`) shells out to `tar`. Issue
+#319 showed it can wedge a reconcile forever. The fix is small, but two decisions
+warrant recording: how the self-exclusion is expressed to `tar`, and how this
+change coexists with the in-flight backup-integrity spec PR #312.
+
+## Decision: exclude by archived-member path, not by container path
+
+`tar` `--exclude` matches against the *member names* tar generates, which are the
+absolute source paths it is told to archive (`/mnt/appdata/bosun`, …). The backup
+destination is configured as `/app/backups` inside the Bosun container, but that is
+a *different mount* than the appdata path tar walks; the same host directory appears
+to tar as `/mnt/appdata/bosun/backups`. So a naive `--exclude=/app/backups` would
+not match anything tar archives.
+
+The implementation MUST derive the exclude from the destination *as it appears under
+the backed-up appdata path*, plus a defensive pattern (e.g. `*/backups/backup-*` and
+the `configs.tar.gz` output name). The `backup_test.go` case that asserts "archive
+does not contain the backups subtree" is the guard that this matched correctly.
+
+## Decision: timeout is a non-fatal failure, not a new abort path
+
+The existing requirement already says backup failures warn and continue. Rather than
+introduce a new fatal timeout behavior, a timeout is funneled into the *same*
+non-fatal failure path. This keeps the blast radius minimal and consistent: a slow
+backup degrades to "no backup this run" with a warning, never a wedged or aborted
+deploy. Default 5m is generous for config-sized backups and well under any operator's
+patience threshold.
+
+## Decision: coordinate with PR #312 rather than fold into it
+
+PR #312 (`add-backup-integrity-semantics`) MODIFIES the same `Configuration Backup`
+requirement, covering integrity and rollback. This change is kept separate so each
+stays independently reviewable (#312 is mid CodeRabbit cycle). The two sets of
+modifications are additive and non-contradictory:
+
+- This change: archive must self-exclude; backup runs under a bounded deadline;
+  verification respects cancellation.
+- #312: deep verification, fail-closed on unverifiable backup, surfaced remote
+  errors, retention deferred until after deploy verification.
+
+Whichever merges second rebases its `MODIFIED Configuration Backup` delta onto the
+first so the resulting requirement text contains both sets of clauses. The
+config-only backup-scope narrowing (issue #319's other suggestion) is deliberately
+left to #312's rollback-integrity work, since it changes what rollback restores from.

--- a/openspec/changes/add-backup-deadline-and-self-exclusion/proposal.md
+++ b/openspec/changes/add-backup-deadline-and-self-exclusion/proposal.md
@@ -1,0 +1,63 @@
+# Change: Bound the pre-deploy backup with a deadline and a self-exclusion invariant
+
+## Why
+
+On a cold/empty-state reconcile (GitHub #319, hit during the GH#214 cutover after
+recreating the Bosun container), the pre-deploy backup step wedges indefinitely and
+nothing downstream deploys. Three intersecting causes, all confirmed in code:
+
+1. **Recursive self-inclusion.** Backup paths come from `backupPathsFromTargets`
+   (`reconcile.go:1125`) as `LocalAppdataPath/<target>`. Bosun is itself a deploy
+   target, so `/mnt/appdata/bosun` is in the list. The tar output lives at
+   `BackupDir` (default `/app/backups` → host `/mnt/appdata/bosun/backups/...`),
+   *inside* a backed-up path, and `tar` (`backup.go:89`) has no `--exclude`. tar
+   archives its own growing output — observed 8 GB and climbing, never terminating.
+
+2. **Context-ignoring verification.** `VerifyBackup` (`backup.go:37`) shells
+   `exec.Command("tar","-tzf",...)` — not `CommandContext` — so no caller deadline
+   can interrupt it. Listing a multi-GB, concurrently-growing archive hangs.
+
+3. **No per-step deadline.** `createBackup` is the only `Run()` pipeline step not
+   wrapped in `context.WithTimeout`; git, ssh, and compose all derive per-step
+   deadlines. The creation tar uses `CommandContext` but inherits an unbounded ctx,
+   so there is no deadline to honor.
+
+The current spec already says *"Backup failures SHALL log a warning but SHALL NOT
+abort the deployment pipeline"* and the call site is already non-fatal. The gap is
+that an unbounded hang is neither success nor failure — it never reaches the
+non-fatal path. Bounding the backup converts the hang into a loud, non-fatal
+failure, which is the behavior the spec already intends.
+
+## What Changes
+
+- **Self-exclusion invariant (MODIFIED Configuration Backup).** The backup archive
+  SHALL NOT include the backup destination directory or any prior backup it
+  contains. When the destination is nested within a backed-up path, the reconciler
+  excludes it.
+- **Bounded deadline (MODIFIED Configuration Backup).** Backup creation and
+  verification run under a configurable `BackupTimeout` (default 5m, env
+  `BOSUN_BACKUP_TIMEOUT`, accepting a Go duration or plain seconds). Timeout is
+  treated as a (non-fatal) backup failure.
+- **Verification respects cancellation (MODIFIED Configuration Backup).**
+  `VerifyBackup` runs under the same context as creation so a deadline aborts it.
+- **New configuration surface:** `BackupTimeout` field + `BOSUN_BACKUP_TIMEOUT`.
+
+Out of scope (deferred to coordinate with the in-flight backup-integrity spec PR
+#312, which MODIFIES this same requirement): narrowing the backup to config-only
+files rather than whole appdata trees. That changes what rollback can restore from,
+which is #312's "Backup-Backed Rollback Integrity" territory.
+
+## Impact
+
+- **Affected spec:** `reconcile` — `Configuration Backup` requirement (MODIFIED).
+- **Coordination:** PR #312 (`add-backup-integrity-semantics`) also MODIFIES
+  `Configuration Backup`. These two changes must be merge-ordered; whichever lands
+  second rebases its delta onto the first. The two sets of modifications are
+  additive (self-exclusion + deadline here; integrity + rollback there) and do not
+  contradict.
+- **Accompanying non-spec fixes shipping in the same implementation PR** (no spec
+  delta — they do not touch spec'd behavior): thread context into the
+  `emergency.go` recovery `runComposeUp`, and cap request-body size on the
+  standalone `bosun webhook` receiver (parity with the daemon's existing 1 MB cap).
+- **Backwards compatibility:** `BackupTimeout` defaults preserve current behavior
+  for any backup that completes within 5 minutes.

--- a/openspec/changes/add-backup-deadline-and-self-exclusion/specs/reconcile/spec.md
+++ b/openspec/changes/add-backup-deadline-and-self-exclusion/specs/reconcile/spec.md
@@ -1,0 +1,68 @@
+## MODIFIED Requirements
+
+### Requirement: Configuration Backup
+
+The reconciler SHALL create a timestamped tar.gz backup of existing
+configuration files before deploying new ones. Backups SHALL be named
+`backup-YYYYMMDD-HHMMSS`.
+
+The reconciler SHALL verify backup integrity after creation by listing the
+archive contents. Empty or corrupted archives SHALL cause the backup to fail.
+Verification SHALL run under the same cancellation context as creation, so a
+caller deadline or cancellation aborts verification rather than blocking
+indefinitely.
+
+The backup archive SHALL NOT include the backup destination directory or any
+prior backup it contains. When the configured backup destination is nested
+within a backed-up path (for example, the reconciler's own appdata directory),
+the reconciler SHALL exclude the destination so the archive cannot recursively
+include its own growing output.
+
+Backup creation and verification SHALL run under a configurable timeout
+(`BackupTimeout`, default 5 minutes, overridable via `BOSUN_BACKUP_TIMEOUT`
+accepting a Go duration or a plain number of seconds). When the timeout
+elapses, the backup SHALL be treated as a failure.
+
+Old backups SHALL be pruned to retain only the most recent N backups
+(configurable via `BackupsToKeep`, default 5).
+
+Backup failures, including timeouts, SHALL log a warning but SHALL NOT abort the
+deployment pipeline.
+
+The last backup path SHALL be stored for potential rollback during compose up.
+
+#### Scenario: Local backup created and verified
+
+- **WHEN** a local deployment runs with existing config files
+- **THEN** a timestamped tar.gz is created containing the config paths
+- **AND** the archive is verified to be non-empty and readable
+
+#### Scenario: Remote backup via SSH
+
+- **WHEN** a remote deployment runs
+- **THEN** a tar command runs over SSH to create the archive
+- **AND** transient SSH errors are retried with exponential backoff
+
+#### Scenario: Backup destination excluded from the archive
+
+- **WHEN** the configured backup destination is nested within a backed-up path
+- **THEN** the created archive does not contain the backup destination directory or any prior backup
+- **AND** the archive size does not grow with the number of prior backups present
+
+#### Scenario: Backup exceeds its timeout
+
+- **WHEN** backup creation or verification runs longer than `BackupTimeout`
+- **THEN** the backup is aborted and treated as a failure
+- **AND** a warning is logged
+- **AND** the deployment continues
+
+#### Scenario: Old backups pruned
+
+- **WHEN** more than `BackupsToKeep` backups exist after a new backup
+- **THEN** the oldest backups are removed, keeping only the most recent N
+
+#### Scenario: Backup failure does not block deploy
+
+- **WHEN** backup creation fails (e.g., no existing configs to backup)
+- **THEN** a warning is logged
+- **AND** the deployment continues

--- a/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
+++ b/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
@@ -1,0 +1,50 @@
+# Tasks
+
+Implementation begins only after this proposal reaches the `ready-to-build` label.
+Each numbered group is a distinct commit.
+
+## 1. Self-exclusion in the backup tar
+
+- [ ] `internal/reconcile/backup.go` — `Backup()`: compute and pass `--exclude` for the
+      backup destination so the creation tar cannot archive its own output tree
+- [ ] Confirm the archived-member path form (absolute `/mnt/appdata/...`) and make the
+      exclude pattern match that form, not the container-local `/app/backups`
+- [ ] `internal/reconcile/backup.go` — `BackupRemote()`: apply the same exclude to the
+      `tar -czf -` over SSH
+- [ ] `internal/reconcile/backup_test.go` — backup dir nested under a backed-up path
+      produces an archive that does NOT contain the backups subtree
+
+## 2. Context-aware verification
+
+- [ ] `internal/reconcile/backup.go` — `VerifyBackup(ctx, backupPath)` using
+      `exec.CommandContext`
+- [ ] Update callers (`Backup`, `BackupRemote`) and the `DeployOps` / interface
+      signature in `internal/reconcile/interfaces.go`
+- [ ] `internal/reconcile/backup_test.go` — `VerifyBackup` honors a cancelled ctx
+
+## 3. Bounded backup deadline
+
+- [ ] `internal/reconcile/reconcile.go` — add `BackupTimeout time.Duration` to `Config`
+- [ ] `internal/reconcile/target.go` — default `BackupTimeout` to 5m in config defaults
+- [ ] Parse `BOSUN_BACKUP_TIMEOUT` (Go duration or plain seconds) mirroring the
+      `BOSUN_COMPOSE_UP_TIMEOUT` pattern
+- [ ] `internal/reconcile/reconcile.go` — `createBackup` wraps ctx in
+      `context.WithTimeout(ctx, BackupTimeout)`; timeout → warn + continue
+- [ ] `internal/reconcile/backup_test.go` — `createBackup` returns within `BackupTimeout`
+      when tar would hang (inject a slow path / fake `DeployOps`)
+
+## 4. Accompanying non-spec Tier-1 fixes (same PR)
+
+- [ ] `internal/cmd/emergency.go` — `runComposeUp(ctx, composeFile)` using
+      `exec.CommandContext`; derive ctx from `cmd.Context()` + a sensible timeout
+- [ ] `internal/cmd/webhook.go` — wrap the 5 `io.ReadAll(r.Body)` calls in
+      `io.LimitReader(r.Body, maxWebhookBodySize)` and set `Server.MaxHeaderBytes`
+- [ ] Tests: `runComposeUp` honors a cancelled ctx; webhook receiver truncates a body
+      over `maxWebhookBodySize` (table-driven over the 5 handlers)
+
+## 5. Docs + validation
+
+- [ ] `skills/onboard/resources/gitops.md` — backup deadline + self-exclusion behavior
+- [ ] `AGENTS.md`/`CLAUDE.md` env-var table — `BOSUN_BACKUP_TIMEOUT`
+- [ ] `make test`
+- [ ] `openspec validate add-backup-deadline-and-self-exclusion --strict`

--- a/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
+++ b/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
@@ -1,4 +1,4 @@
-# Tasks
+## Tasks
 
 Implementation begins only after this proposal reaches the `ready-to-build` label.
 Each numbered group is a distinct commit.


### PR DESCRIPTION
## Summary

Spec-only change proposal (no implementation) bounding the pre-deploy backup so a
cold/empty-state reconcile cannot wedge indefinitely. Fixes the root cause of
**#319**, hit during the GH#214 cutover.

The backup `tar` (`internal/reconcile/backup.go`) currently:
1. archives **its own growing output** — `BackupDir` (`/app/backups` → host
   `/mnt/appdata/bosun/backups`) is nested inside a backed-up path and tar has no
   `--exclude` (observed 8 GB and climbing);
2. **ignores context in verification** — `VerifyBackup` uses plain `exec.Command`;
3. **has no per-step deadline** — `createBackup` is the only `Run()` step not wrapped
   in `context.WithTimeout`.

## Spec delta (`openspec/changes/add-backup-deadline-and-self-exclusion/`)

**MODIFIED** `Configuration Backup` (reconcile capability):
- archive SHALL NOT include the backup destination / prior backups (self-exclusion)
- creation + verification SHALL run under `BackupTimeout` (default 5m,
  `BOSUN_BACKUP_TIMEOUT`); timeout is a **non-fatal** failure (consistent with the
  existing "warn, don't abort" clause)
- verification SHALL respect the caller's cancellation context

`openspec validate add-backup-deadline-and-self-exclusion --strict` → valid.

## Coordination with PR #312

PR #312 (`add-backup-integrity-semantics`) MODIFIES the **same** `Configuration
Backup` requirement (integrity + rollback). Kept **separate** so each stays
independently reviewable; deltas are additive and non-contradictory. Whichever
merges second rebases its delta onto the first. The config-only backup-scope
narrowing (issue #319's other suggestion) is intentionally deferred to #312's
rollback-integrity work.

## Out of scope for the spec (ship in the apply PR, no spec delta)

Two non-spec-coupled wedge-class siblings found in the same sweep, fixed alongside
the implementation: `emergency.go` recovery `runComposeUp` gets a context; the
standalone `bosun webhook` receiver gets the daemon's 1 MB body cap.

Refs bosun-k88

🤖 Generated with [Claude Code](https://claude.com/claude-code)