### PR TITLE
fix(cmd): bound recovery compose-up + cap webhook receiver body size (bosun-9nm)

### DIFF
--- a/internal/cmd/emergency.go
+++ b/internal/cmd/emergency.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -385,7 +386,7 @@ func runRestore(cmd *cobra.Command, args []string) error {
 	}
 
 	backupName := args[0]
-	return doRestore(backupDir, backupName)
+	return doRestore(cmd.Context(), backupDir, backupName)
 }
 
 // getBackupDir returns the backup directory path.
@@ -490,7 +491,7 @@ func getBackups(backupDir string) ([]BackupInfo, error) {
 	return backups, nil
 }
 
-func doRestore(backupDir, backupName string) error {
+func doRestore(ctx context.Context, backupDir, backupName string) error {
 	backupPath := filepath.Join(backupDir, backupName)
 
 	// Validate backup exists
@@ -571,7 +572,7 @@ func doRestore(backupDir, backupName string) error {
 	composeFile := filepath.Join(targetDir, "compose", "core.yml")
 	if _, err := os.Stat(composeFile); err == nil {
 		ui.Info("  Restarting services...")
-		if err := runComposeUp(composeFile); err != nil {
+		if err := runComposeUp(ctx, composeFile); err != nil {
 			ui.Warning("Could not restart services: %v", err)
 			_, _ = ui.Yellow.Println("  Run 'docker compose -f " + composeFile + " up -d' manually")
 		}
@@ -726,8 +727,17 @@ func deployRestoredConfigs(stagingDir, targetDir string) error {
 	return fileutil.CopyDir(stagingDir, targetDir)
 }
 
-func runComposeUp(composeFile string) error {
-	cmd := exec.Command("docker", "compose", "-f", composeFile, "up", "-d", "--remove-orphans")
+// recoveryComposeUpTimeout bounds the disaster-recovery compose-up so the
+// recovery path cannot wedge indefinitely the way the pre-deploy backup did (#319).
+const recoveryComposeUpTimeout = 10 * time.Minute
+
+func runComposeUp(ctx context.Context, composeFile string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, recoveryComposeUpTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "compose", "-f", composeFile, "up", "-d", "--remove-orphans")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/internal/cmd/webhook.go
+++ b/internal/cmd/webhook.go
@@ -124,7 +124,7 @@ func runWebhook(cmd *cobra.Command, args []string) {
 		ReadTimeout:    10 * time.Second,
 		WriteTimeout:   30 * time.Second,
 		IdleTimeout:    60 * time.Second,
-		MaxHeaderBytes: maxWebhookBodySize,
+		MaxHeaderBytes: maxWebhookHeaderBytes,
 	}
 
 	// Start server in goroutine
@@ -161,6 +161,11 @@ func runWebhook(cmd *cobra.Command, args []string) {
 // prevent unbounded reads from a tunnel-exposed endpoint (mirrors the daemon's
 // own 1MB limit in internal/daemon/server.go).
 const maxWebhookBodySize = 1 << 20 // 1MB
+
+// maxWebhookHeaderBytes caps request header size (request line + header fields),
+// which is distinct from the body limit above. 64KB is generous for webhook
+// headers while bounding header-based memory abuse.
+const maxWebhookHeaderBytes = 64 * 1024 // 64KB
 
 type webhookHandler struct {
 	client *daemon.Client

--- a/internal/cmd/webhook.go
+++ b/internal/cmd/webhook.go
@@ -121,9 +121,10 @@ func runWebhook(cmd *cobra.Command, args []string) {
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", webhookPort),
 		Handler:      mux,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 30 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   30 * time.Second,
+		IdleTimeout:    60 * time.Second,
+		MaxHeaderBytes: maxWebhookBodySize,
 	}
 
 	// Start server in goroutine
@@ -156,6 +157,11 @@ func runWebhook(cmd *cobra.Command, args []string) {
 	ui.Success("Webhook server stopped")
 }
 
+// maxWebhookBodySize caps request bodies on the standalone webhook receiver to
+// prevent unbounded reads from a tunnel-exposed endpoint (mirrors the daemon's
+// own 1MB limit in internal/daemon/server.go).
+const maxWebhookBodySize = 1 << 20 // 1MB
+
 type webhookHandler struct {
 	client *daemon.Client
 	secret string
@@ -168,7 +174,7 @@ func (h *webhookHandler) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Read body for signature validation
-	body, err := io.ReadAll(r.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBodySize))
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
 		return
@@ -212,7 +218,7 @@ func (h *webhookHandler) handleGitHubWebhook(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Read body
-	body, err := io.ReadAll(r.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBodySize))
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
 		return
@@ -282,7 +288,7 @@ func (h *webhookHandler) handleGitLabWebhook(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Read body
-	body, err := io.ReadAll(r.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBodySize))
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
 		return
@@ -345,7 +351,7 @@ func (h *webhookHandler) handleGiteaWebhook(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Read body
-	body, err := io.ReadAll(r.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBodySize))
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
 		return
@@ -410,7 +416,7 @@ func (h *webhookHandler) handleBitbucketWebhook(w http.ResponseWriter, r *http.R
 	}
 
 	// Read body
-	body, err := io.ReadAll(r.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBodySize))
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
 		return

--- a/internal/cmd/wedge_class_test.go
+++ b/internal/cmd/wedge_class_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunComposeUp_HonorsCancelledContext proves the disaster-recovery compose-up
+// honors context cancellation rather than running unbounded (sibling of #319).
+func TestRunComposeUp_HonorsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the call
+
+	err := runComposeUp(ctx, filepath.Join(t.TempDir(), "core.yml"))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestWebhookHandlers_RejectOversizedBody proves the standalone (tunnel-exposed)
+// webhook receiver caps request-body size like the daemon's own handlers do,
+// instead of reading an unbounded body into memory.
+func TestWebhookHandlers_RejectOversizedBody(t *testing.T) {
+	h := &webhookHandler{secret: ""} // no secret: would otherwise forward to a nil client
+
+	oversized := bytes.Repeat([]byte("a"), maxWebhookBodySize+1)
+
+	cases := []struct {
+		name string
+		path string
+		fn   func(http.ResponseWriter, *http.Request)
+	}{
+		{"generic", "/webhook", h.handleWebhook},
+		{"github", "/webhook/github", h.handleGitHubWebhook},
+		{"gitlab", "/webhook/gitlab", h.handleGitLabWebhook},
+		{"gitea", "/webhook/gitea", h.handleGiteaWebhook},
+		{"bitbucket", "/webhook/bitbucket", h.handleBitbucketWebhook},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, c.path, bytes.NewReader(oversized))
+			rec := httptest.NewRecorder()
+
+			c.fn(rec, req)
+
+			assert.GreaterOrEqualf(t, rec.Code, 400, "oversized body must be rejected, got %d", rec.Code)
+			assert.Lessf(t, rec.Code, 500, "rejection should be a client error, got %d", rec.Code)
+		})
+	}
+}

--- a/internal/cmd/wedge_class_test.go
+++ b/internal/cmd/wedge_class_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,24 @@ func TestRunComposeUp_HonorsCancelledContext(t *testing.T) {
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestRunComposeUp_ReturnsErrorOnMissingComposeFile exercises the exec path
+// (timeout wrap + CommandContext + Run) with a live context: a nonexistent
+// compose file makes `docker compose up` fail fast, so the call returns an error
+// promptly rather than hanging — and does so regardless of Docker availability.
+func TestRunComposeUp_ReturnsErrorOnMissingComposeFile(t *testing.T) {
+	done := make(chan error, 1)
+	go func() {
+		done <- runComposeUp(context.Background(), filepath.Join(t.TempDir(), "does-not-exist.yml"))
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("runComposeUp did not return promptly for a missing compose file")
+	}
 }
 
 // TestWebhookHandlers_RejectOversizedBody proves the standalone (tunnel-exposed)


### PR DESCRIPTION
## Summary

Two non-spec-coupled **wedge-class** siblings of #319, found in the May 2026 sweep
and split out so they ship in parallel while the #319 spec (PR #320) is in review.

### 1. `emergency.go` — disaster recovery can no longer hang

`runComposeUp` shelled `docker compose up` via raw `exec.Command` with **no
context**. The recovery path had the same indefinite-hang failure mode as the trap
it's meant to escape. Now:
- `runComposeUp(ctx, composeFile)` fast-fails on an already-cancelled ctx and runs
  under a 10m `recoveryComposeUpTimeout` via `exec.CommandContext`
- ctx is threaded through `doRestore` from `runRestore` (`cmd.Context()`)

### 2. `webhook.go` — body-size cap on the tunnel-exposed receiver

The standalone `bosun webhook` receiver (GitLab/Gitea/Bitbucket, reachable through
the radio/tunnel) read request bodies with raw `io.ReadAll(r.Body)` — **no cap** —
while the daemon's own handlers cap every body at 1MB. Internet-facing memory-
exhaustion DoS. All 5 handlers now wrap `r.Body` in `http.MaxBytesReader(w, r.Body,
maxWebhookBodySize)` so an oversized body errors into the existing `400` path
instead of being read into memory or forwarded; `Server.MaxHeaderBytes` set to match.

## Tests (TDD red→green)

`internal/cmd/wedge_class_test.go`:
- `TestRunComposeUp_HonorsCancelledContext` — returns `context.Canceled` on a
  cancelled ctx (deterministic, no Docker needed)
- `TestWebhookHandlers_RejectOversizedBody` — table-driven over all 5 handlers, each
  rejects a body over the cap with a 4xx

`go test ./internal/cmd/` ✅ · `make build` ✅. (The one failing test in the full
suite, `reconcile/...full_non-dry-run_local_deploy...`, requires a live Docker
daemon — environmental, in a package this PR doesn't touch.)

## Scope

Confined to `internal/cmd/`. The #319 backup fix (`backup.go` self-exclusion +
`BackupTimeout`) stays gated on spec PR #320 reaching `ready-to-build`.

Refs bosun-9nm

🤖 Generated with [Claude Code](https://claude.com/claude-code)