### PR TITLE
feat(log): structured logging for docker and manifest packages (bosun-ixv)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ bosun/bosun
 /.beads/**/*.db
 /.beads-credential-key
 /.review-loop.local.md
+.claude/intros/

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -79,14 +79,25 @@ func NewClientWithAPI(api DockerAPI) *Client {
 
 // Ping tests the connection to the Docker daemon.
 func (c *Client) Ping(ctx context.Context) error {
+	start := time.Now()
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Debug().Msg("Testing Docker daemon connection")
+
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	_, err := c.api.Ping(ctx)
 	if err != nil {
+		logger.Error().
+			Err(err).
+			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Msg("Failed to ping Docker daemon")
 		return fmt.Errorf("ping docker: %w", err)
 	}
 
+	logger.Debug().
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Successfully pinged Docker daemon")
 	return nil
 }
 
@@ -181,8 +192,13 @@ func (c *Client) ListContainers(ctx context.Context, runningOnly bool) ([]Contai
 
 // CountContainers returns counts of running, total, and unhealthy containers.
 func (c *Client) CountContainers(ctx context.Context) (running, total, unhealthy int, err error) {
+	start := time.Now()
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Debug().Msg("Counting containers by state")
+
 	containers, err := c.ListContainers(ctx, false)
 	if err != nil {
+		logger.Error().Err(err).Msg("Failed to count containers")
 		return 0, 0, 0, err
 	}
 
@@ -196,22 +212,34 @@ func (c *Client) CountContainers(ctx context.Context) (running, total, unhealthy
 		}
 	}
 
+	logger.Info().
+		Int("running", running).
+		Int("total", total).
+		Int("unhealthy", unhealthy).
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Container counts obtained")
 	return running, total, unhealthy, nil
 }
 
 // GetContainerByName returns a container by its name.
 func (c *Client) GetContainerByName(ctx context.Context, name string) (*ContainerInfo, error) {
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Debug().Str(log.FieldContainer, name).Msg("Looking up container by name")
+
 	containers, err := c.ListContainers(ctx, false)
 	if err != nil {
+		logger.Error().Str(log.FieldContainer, name).Err(err).Msg("Failed to list containers for lookup")
 		return nil, err
 	}
 
 	for _, ctr := range containers {
 		if ctr.Name == name {
+			logger.Debug().Str(log.FieldContainer, name).Msg("Found container")
 			return &ctr, nil
 		}
 	}
 
+	logger.Warn().Str(log.FieldContainer, name).Msg("Container not found")
 	return nil, fmt.Errorf("container not found: %s", name)
 }
 

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -90,13 +90,13 @@ func (c *Client) Ping(ctx context.Context) error {
 	if err != nil {
 		logger.Error().
 			Err(err).
-			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Int64(log.FieldDurationMS, log.DurationMS(start)).
 			Msg("Failed to ping Docker daemon")
 		return fmt.Errorf("ping docker: %w", err)
 	}
 
 	logger.Debug().
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Successfully pinged Docker daemon")
 	return nil
 }
@@ -152,7 +152,7 @@ func (c *Client) ListContainers(ctx context.Context, runningOnly bool) ([]Contai
 		All: !runningOnly,
 	})
 	if err != nil {
-		logger.Error().Err(err).Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).Msg("Failed to list containers")
+		logger.Error().Err(err).Int64(log.FieldDurationMS, log.DurationMS(start)).Msg("Failed to list containers")
 		return nil, fmt.Errorf("list containers: %w", err)
 	}
 
@@ -185,7 +185,7 @@ func (c *Client) ListContainers(ctx context.Context, runningOnly bool) ([]Contai
 
 	logger.Debug().
 		Int("count", len(result)).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Listed containers successfully")
 	return result, nil
 }
@@ -216,7 +216,7 @@ func (c *Client) CountContainers(ctx context.Context) (running, total, unhealthy
 		Int("running", running).
 		Int("total", total).
 		Int("unhealthy", unhealthy).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Container counts obtained")
 	return running, total, unhealthy, nil
 }

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -85,7 +85,7 @@ func (c *ComposeClient) Up(ctx context.Context, services ...string) error {
 			Err(err).
 			Str("project", c.project).
 			Int("service_count", serviceCount).
-			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Int64(log.FieldDurationMS, log.DurationMS(start)).
 			Msg("Failed to start services with docker compose up")
 		return fmt.Errorf("docker compose up: %w\n%s", err, output)
 	}
@@ -93,7 +93,7 @@ func (c *ComposeClient) Up(ctx context.Context, services ...string) error {
 	logger.Info().
 		Str("project", c.project).
 		Int("service_count", serviceCount).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Successfully started services with docker compose up")
 	return nil
 }
@@ -113,14 +113,14 @@ func (c *ComposeClient) Down(ctx context.Context) error {
 		logger.Error().
 			Err(err).
 			Str("project", c.project).
-			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Int64(log.FieldDurationMS, log.DurationMS(start)).
 			Msg("Failed to stop and remove services with docker compose down")
 		return fmt.Errorf("docker compose down: %w\n%s", err, output)
 	}
 
 	logger.Info().
 		Str("project", c.project).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Successfully stopped and removed services with docker compose down")
 	return nil
 }
@@ -145,7 +145,7 @@ func (c *ComposeClient) DownWithTimeout(ctx context.Context, timeoutSeconds int)
 			Err(err).
 			Str("project", c.project).
 			Int("timeout_seconds", timeoutSeconds).
-			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Int64(log.FieldDurationMS, log.DurationMS(start)).
 			Msg("Failed to stop and remove services with docker compose down")
 		return fmt.Errorf("docker compose down: %w\n%s", err, output)
 	}
@@ -153,7 +153,7 @@ func (c *ComposeClient) DownWithTimeout(ctx context.Context, timeoutSeconds int)
 	logger.Info().
 		Str("project", c.project).
 		Int("timeout_seconds", timeoutSeconds).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Successfully stopped and removed services with docker compose down")
 	return nil
 }
@@ -180,7 +180,7 @@ func (c *ComposeClient) Restart(ctx context.Context, services ...string) error {
 			Err(err).
 			Str("project", c.project).
 			Int("service_count", serviceCount).
-			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Int64(log.FieldDurationMS, log.DurationMS(start)).
 			Msg("Failed to restart services with docker compose restart")
 		return fmt.Errorf("docker compose restart: %w\n%s", err, output)
 	}
@@ -188,7 +188,7 @@ func (c *ComposeClient) Restart(ctx context.Context, services ...string) error {
 	logger.Info().
 		Str("project", c.project).
 		Int("service_count", serviceCount).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Successfully restarted services with docker compose restart")
 	return nil
 }
@@ -210,7 +210,7 @@ func (c *ComposeClient) Status(ctx context.Context) ([]ServiceStatus, error) {
 		logger.Error().
 			Err(err).
 			Str("project", c.project).
-			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Int64(log.FieldDurationMS, log.DurationMS(start)).
 			Msg("Failed to fetch service status with docker compose ps")
 		return nil, fmt.Errorf("docker compose ps: %w\n%s", err, stderr.String())
 	}
@@ -243,7 +243,7 @@ func (c *ComposeClient) Status(ctx context.Context) ([]ServiceStatus, error) {
 	logger.Info().
 		Str("project", c.project).
 		Int("service_count", len(services)).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Successfully fetched service status")
 	return services, nil
 }
@@ -263,7 +263,7 @@ func (c *ComposeClient) Ps(ctx context.Context) (string, error) {
 		logger.Error().
 			Err(err).
 			Str("project", c.project).
-			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Int64(log.FieldDurationMS, log.DurationMS(start)).
 			Msg("Failed to run docker compose ps")
 		return "", fmt.Errorf("docker compose ps: %w\n%s", err, output)
 	}
@@ -271,7 +271,7 @@ func (c *ComposeClient) Ps(ctx context.Context) (string, error) {
 	logger.Debug().
 		Str("project", c.project).
 		Int("output_size", len(output)).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Successfully ran docker compose ps")
 	return string(output), nil
 }

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
+
+	"github.com/cameronsjo/bosun/internal/log"
 )
 
 // ServiceStatus represents the status of a docker compose service.
@@ -62,6 +65,15 @@ func (c *ComposeClient) baseArgs() []string {
 
 // Up starts services defined in the compose file.
 func (c *ComposeClient) Up(ctx context.Context, services ...string) error {
+	start := time.Now()
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	serviceCount := len(services)
+	if serviceCount == 0 {
+		logger.Debug().Str("project", c.project).Msg("Preparing to start all services with docker compose up")
+	} else {
+		logger.Debug().Str("project", c.project).Int("service_count", serviceCount).Msg("Preparing to start specific services with docker compose up")
+	}
+
 	args := c.baseArgs()
 	args = append(args, "up", "-d")
 	args = append(args, services...)
@@ -69,43 +81,94 @@ func (c *ComposeClient) Up(ctx context.Context, services ...string) error {
 	cmd := c.command(ctx, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		logger.Error().
+			Err(err).
+			Str("project", c.project).
+			Int("service_count", serviceCount).
+			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Msg("Failed to start services with docker compose up")
 		return fmt.Errorf("docker compose up: %w\n%s", err, output)
 	}
 
+	logger.Info().
+		Str("project", c.project).
+		Int("service_count", serviceCount).
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Successfully started services with docker compose up")
 	return nil
 }
 
 // Down stops and removes services defined in the compose file.
 func (c *ComposeClient) Down(ctx context.Context) error {
+	start := time.Now()
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Info().Str("project", c.project).Msg("Preparing to stop and remove services with docker compose down")
+
 	args := c.baseArgs()
 	args = append(args, "down")
 
 	cmd := c.command(ctx, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		logger.Error().
+			Err(err).
+			Str("project", c.project).
+			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Msg("Failed to stop and remove services with docker compose down")
 		return fmt.Errorf("docker compose down: %w\n%s", err, output)
 	}
 
+	logger.Info().
+		Str("project", c.project).
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Successfully stopped and removed services with docker compose down")
 	return nil
 }
 
 // DownWithTimeout stops and removes services with a custom shutdown timeout.
 // The timeout is the grace period (in seconds) between SIGTERM and SIGKILL for each container.
 func (c *ComposeClient) DownWithTimeout(ctx context.Context, timeoutSeconds int) error {
+	start := time.Now()
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Info().
+		Str("project", c.project).
+		Int("timeout_seconds", timeoutSeconds).
+		Msg("Preparing to stop and remove services with docker compose down")
+
 	args := c.baseArgs()
 	args = append(args, "down", "--timeout", fmt.Sprintf("%d", timeoutSeconds))
 
 	cmd := c.command(ctx, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		logger.Error().
+			Err(err).
+			Str("project", c.project).
+			Int("timeout_seconds", timeoutSeconds).
+			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Msg("Failed to stop and remove services with docker compose down")
 		return fmt.Errorf("docker compose down: %w\n%s", err, output)
 	}
 
+	logger.Info().
+		Str("project", c.project).
+		Int("timeout_seconds", timeoutSeconds).
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Successfully stopped and removed services with docker compose down")
 	return nil
 }
 
 // Restart restarts services defined in the compose file.
 func (c *ComposeClient) Restart(ctx context.Context, services ...string) error {
+	start := time.Now()
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	serviceCount := len(services)
+	if serviceCount == 0 {
+		logger.Debug().Str("project", c.project).Msg("Preparing to restart all services with docker compose restart")
+	} else {
+		logger.Debug().Str("project", c.project).Int("service_count", serviceCount).Msg("Preparing to restart specific services with docker compose restart")
+	}
+
 	args := c.baseArgs()
 	args = append(args, "restart")
 	args = append(args, services...)
@@ -113,14 +176,29 @@ func (c *ComposeClient) Restart(ctx context.Context, services ...string) error {
 	cmd := c.command(ctx, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		logger.Error().
+			Err(err).
+			Str("project", c.project).
+			Int("service_count", serviceCount).
+			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Msg("Failed to restart services with docker compose restart")
 		return fmt.Errorf("docker compose restart: %w\n%s", err, output)
 	}
 
+	logger.Info().
+		Str("project", c.project).
+		Int("service_count", serviceCount).
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Successfully restarted services with docker compose restart")
 	return nil
 }
 
 // Status returns the status of services in the compose file.
 func (c *ComposeClient) Status(ctx context.Context) ([]ServiceStatus, error) {
+	start := time.Now()
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Debug().Str("project", c.project).Msg("Fetching service status with docker compose ps")
+
 	args := c.baseArgs()
 	args = append(args, "ps", "--format", "{{.Name}}\t{{.State}}\t{{.Status}}\t{{.Ports}}")
 	cmd := c.command(ctx, args...)
@@ -129,6 +207,11 @@ func (c *ComposeClient) Status(ctx context.Context) ([]ServiceStatus, error) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
+		logger.Error().
+			Err(err).
+			Str("project", c.project).
+			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Msg("Failed to fetch service status with docker compose ps")
 		return nil, fmt.Errorf("docker compose ps: %w\n%s", err, stderr.String())
 	}
 
@@ -157,19 +240,38 @@ func (c *ComposeClient) Status(ctx context.Context) ([]ServiceStatus, error) {
 		services = append(services, svc)
 	}
 
+	logger.Info().
+		Str("project", c.project).
+		Int("service_count", len(services)).
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Successfully fetched service status")
 	return services, nil
 }
 
 // Ps runs docker compose ps and returns the raw output.
 func (c *ComposeClient) Ps(ctx context.Context) (string, error) {
+	start := time.Now()
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Debug().Str("project", c.project).Msg("Running docker compose ps")
+
 	args := c.baseArgs()
 	args = append(args, "ps")
 
 	cmd := c.command(ctx, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		logger.Error().
+			Err(err).
+			Str("project", c.project).
+			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Msg("Failed to run docker compose ps")
 		return "", fmt.Errorf("docker compose ps: %w\n%s", err, output)
 	}
 
+	logger.Debug().
+		Str("project", c.project).
+		Int("output_size", len(output)).
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Successfully ran docker compose ps")
 	return string(output), nil
 }

--- a/internal/docker/containers.go
+++ b/internal/docker/containers.go
@@ -99,7 +99,7 @@ func (c *Client) Inspect(ctx context.Context, name string) (*ContainerDetails, e
 		logger.Error().
 			Str(log.FieldContainer, name).
 			Err(err).
-			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Int64(log.FieldDurationMS, log.DurationMS(start)).
 			Msg("Failed to inspect container")
 		return nil, fmt.Errorf("inspect container %s: %w", name, err)
 	}
@@ -172,7 +172,7 @@ func (c *Client) Inspect(ctx context.Context, name string) (*ContainerDetails, e
 		Str("state", details.State).
 		Str("health", details.Health).
 		Int("port_count", len(details.Ports)).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Successfully inspected container")
 	return details, nil
 }

--- a/internal/docker/containers.go
+++ b/internal/docker/containers.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+
+	"github.com/cameronsjo/bosun/internal/log"
 )
 
 // HealthCheckLog holds the last health check result for a container.
@@ -53,6 +55,13 @@ type PortBinding struct {
 //
 // For non-streaming use cases, prefer GetContainerLogs which handles cleanup automatically.
 func (c *Client) Logs(ctx context.Context, name string, tail int, follow bool) (io.ReadCloser, error) {
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Debug().
+		Str(log.FieldContainer, name).
+		Int("tail", tail).
+		Bool("follow", follow).
+		Msg("Opening log stream for container")
+
 	tailStr := "all"
 	if tail > 0 {
 		tailStr = fmt.Sprintf("%d", tail)
@@ -68,16 +77,30 @@ func (c *Client) Logs(ctx context.Context, name string, tail int, follow bool) (
 
 	reader, err := c.api.ContainerLogs(ctx, name, options)
 	if err != nil {
+		logger.Error().
+			Str(log.FieldContainer, name).
+			Err(err).
+			Msg("Failed to open log stream for container")
 		return nil, fmt.Errorf("get logs for %s: %w", name, err)
 	}
 
+	logger.Debug().Str(log.FieldContainer, name).Msg("Successfully opened log stream for container")
 	return reader, nil
 }
 
 // Inspect returns detailed information about a container.
 func (c *Client) Inspect(ctx context.Context, name string) (*ContainerDetails, error) {
+	start := time.Now()
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Debug().Str(log.FieldContainer, name).Msg("Inspecting container")
+
 	info, err := c.api.ContainerInspect(ctx, name)
 	if err != nil {
+		logger.Error().
+			Str(log.FieldContainer, name).
+			Err(err).
+			Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+			Msg("Failed to inspect container")
 		return nil, fmt.Errorf("inspect container %s: %w", name, err)
 	}
 
@@ -144,6 +167,13 @@ func (c *Client) Inspect(ctx context.Context, name string) (*ContainerDetails, e
 		details.Platform = info.Platform
 	}
 
+	logger.Debug().
+		Str(log.FieldContainer, name).
+		Str("state", details.State).
+		Str("health", details.Health).
+		Int("port_count", len(details.Ports)).
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Successfully inspected container")
 	return details, nil
 }
 
@@ -163,16 +193,29 @@ func (c *Client) Remove(ctx context.Context, name string, force bool) error {
 
 // Start starts a stopped container.
 func (c *Client) Start(ctx context.Context, name string) error {
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Info().Str(log.FieldContainer, name).Msg("Starting container")
+
 	if err := c.api.ContainerStart(ctx, name, container.StartOptions{}); err != nil {
+		logger.Error().
+			Str(log.FieldContainer, name).
+			Err(err).
+			Msg("Failed to start container")
 		return fmt.Errorf("start container %s: %w", name, err)
 	}
+
+	logger.Info().Str(log.FieldContainer, name).Msg("Container started successfully")
 	return nil
 }
 
 // Exists checks if a container with the given name exists (running or stopped).
 func (c *Client) Exists(ctx context.Context, name string) (bool, error) {
+	logger := log.ComponentCtx(ctx, log.ComponentDocker)
+	logger.Debug().Str(log.FieldContainer, name).Msg("Checking if container exists")
+
 	containers, err := c.api.ContainerList(ctx, container.ListOptions{All: true})
 	if err != nil {
+		logger.Error().Str(log.FieldContainer, name).Err(err).Msg("Failed to list containers for existence check")
 		return false, fmt.Errorf("list containers: %w", err)
 	}
 
@@ -182,11 +225,13 @@ func (c *Client) Exists(ctx context.Context, name string) (bool, error) {
 	for _, ctr := range containers {
 		for _, n := range ctr.Names {
 			if strings.TrimPrefix(n, "/") == normalizedName {
+				logger.Debug().Str(log.FieldContainer, name).Msg("Container exists")
 				return true, nil
 			}
 		}
 	}
 
+	logger.Debug().Str(log.FieldContainer, name).Msg("Container does not exist")
 	return false, nil
 }
 

--- a/internal/manifest/interpolate.go
+++ b/internal/manifest/interpolate.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/cameronsjo/bosun/internal/log"
 )
 
 // varPattern matches ${varname} placeholders.
@@ -29,6 +31,10 @@ func Interpolate(template string, variables map[string]any) (string, error) {
 	})
 
 	if len(missingVars) > 0 {
+		logger := log.Component(log.ComponentManifest)
+		logger.Warn().
+			Strs("missing_variables", missingVars).
+			Msg("Variable interpolation failed due to missing variables")
 		return "", fmt.Errorf("missing variables: ${%s}", strings.Join(missingVars, "}, ${"))
 	}
 

--- a/internal/manifest/provision.go
+++ b/internal/manifest/provision.go
@@ -18,18 +18,24 @@ func LoadProvision(provisionName string, variables map[string]any, provisionsDir
 }
 
 func loadProvisionInternal(provisionName string, variables map[string]any, provisionsDir string, loaded map[string]bool) (*Provision, error) {
+	logger := log.Component(log.ComponentManifest)
+
 	// Prevent circular includes - return error instead of silently ignoring
 	if loaded[provisionName] {
+		logger.Error().Str("provision", provisionName).Msg("Circular include detected")
 		return nil, fmt.Errorf("provision %s: %w", provisionName, ErrCircularInclude)
 	}
 	loaded[provisionName] = true
+	logger.Debug().Str("provision", provisionName).Msg("Loading provision")
 
 	provisionPath := filepath.Join(provisionsDir, provisionName+".yml")
 	rawContent, err := os.ReadFile(provisionPath)
 	if err != nil {
 		if os.IsNotExist(err) {
+			logger.Error().Str("provision", provisionName).Str(log.FieldPath, provisionPath).Msg("Provision file not found")
 			return nil, fmt.Errorf("provision not found: %s", provisionPath)
 		}
+		logger.Error().Str("provision", provisionName).Str(log.FieldPath, provisionPath).Err(err).Msg("Failed to read provision file")
 		return nil, fmt.Errorf("read provision %s: %w", provisionPath, err)
 	}
 
@@ -57,12 +63,14 @@ func loadProvisionInternal(provisionName string, variables map[string]any, provi
 	// Interpolate BEFORE YAML parsing
 	interpolated, err := Interpolate(string(rawContent), variables)
 	if err != nil {
+		logger.Error().Str("provision", provisionName).Err(err).Msg("Failed to interpolate provision variables")
 		return nil, fmt.Errorf("interpolate provision %s: %w", provisionName, err)
 	}
 
 	// Parse YAML into raw map to handle includes
 	var rawProvision map[string]any
 	if err := yaml.Unmarshal([]byte(interpolated), &rawProvision); err != nil {
+		logger.Error().Str("provision", provisionName).Err(err).Msg("Failed to parse provision YAML")
 		return nil, fmt.Errorf("parse provision %s: %w", provisionName, err)
 	}
 
@@ -90,11 +98,24 @@ func loadProvisionInternal(provisionName string, variables map[string]any, provi
 
 	// Handle inheritance - load included provisions first, then merge this on top
 	if len(includes) > 0 {
+		logger.Debug().
+			Str("provision", provisionName).
+			Int("include_count", len(includes)).
+			Msg("Processing provision includes")
 		result := make(map[string]map[string]any)
 
 		for _, included := range includes {
+			logger.Debug().
+				Str("provision", provisionName).
+				Str("included_provision", included).
+				Msg("Loading included provision")
 			includedProvision, err := loadProvisionInternal(included, variables, provisionsDir, loaded)
 			if err != nil {
+				logger.Error().
+					Str("provision", provisionName).
+					Str("included_provision", included).
+					Err(err).
+					Msg("Failed to load included provision")
 				return nil, fmt.Errorf("include %s in %s: %w", included, provisionName, err)
 			}
 
@@ -137,11 +158,16 @@ func loadProvisionInternal(provisionName string, variables map[string]any, provi
 
 // ListProvisions returns the names of all available provisions.
 func ListProvisions(provisionsDir string) ([]string, error) {
+	logger := log.Component(log.ComponentManifest)
+	logger.Debug().Str(log.FieldPath, provisionsDir).Msg("Listing available provisions")
+
 	entries, err := os.ReadDir(provisionsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
+			logger.Warn().Str(log.FieldPath, provisionsDir).Msg("Provisions directory not found")
 			return nil, fmt.Errorf("provisions directory not found: %s", provisionsDir)
 		}
+		logger.Error().Str(log.FieldPath, provisionsDir).Err(err).Msg("Failed to read provisions directory")
 		return nil, fmt.Errorf("read provisions directory: %w", err)
 	}
 
@@ -156,6 +182,10 @@ func ListProvisions(provisionsDir string) ([]string, error) {
 		}
 	}
 
+	logger.Debug().
+		Str(log.FieldPath, provisionsDir).
+		Int("provision_count", len(provisions)).
+		Msg("Listed available provisions")
 	return provisions, nil
 }
 

--- a/internal/manifest/render.go
+++ b/internal/manifest/render.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -185,15 +186,20 @@ func mergeProvision(output *RenderOutput, provision *Provision) {
 
 // RenderStack renders a stack file into compose/traefik/gatus outputs.
 func RenderStack(stackPath, provisionsDir, servicesDir string, valuesOverlay map[string]any) (*RenderOutput, error) {
+	start := time.Now()
 	logger := log.Component(log.ComponentManifest)
 	logger.Info().
 		Str(log.FieldOperation, "render_stack").
 		Str(log.FieldPath, stackPath).
-		Msg("Rendering stack")
+		Int("overlay_count", len(valuesOverlay)).
+		Msg("Preparing to render stack")
 
 	stackContent, err := os.ReadFile(stackPath)
 	if err != nil {
-		logger.Error().Err(err).Str(log.FieldPath, stackPath).Msg("Failed to read stack file")
+		logger.Error().
+			Err(err).
+			Str(log.FieldPath, stackPath).
+			Msg("Failed to read stack file")
 		return nil, fmt.Errorf("read stack file: %w", err)
 	}
 
@@ -277,7 +283,11 @@ func RenderStack(stackPath, provisionsDir, servicesDir string, valuesOverlay map
 
 		serviceOutput, err := RenderService(&manifest, provisionsDir)
 		if err != nil {
-			logger.Error().Err(err).Str("service", manifest.Name).Msg("Failed to render service")
+			logger.Error().
+				Err(err).
+				Str("service", manifest.Name).
+				Str("service_file", serviceFile).
+				Msg("Failed to render service in stack")
 			return nil, fmt.Errorf("render service %s: %w", manifest.Name, err)
 		}
 
@@ -290,6 +300,7 @@ func RenderStack(stackPath, provisionsDir, servicesDir string, valuesOverlay map
 
 	// Merge network definitions from stack (don't overwrite service networks)
 	if stack.Networks != nil {
+		logger.Debug().Int("network_count", len(stack.Networks)).Msg("Merging stack network definitions")
 		compose := output.Target(TargetCompose)
 		if existing, ok := compose["networks"].(map[string]any); ok {
 			compose["networks"] = DeepMerge(existing, stack.Networks)
@@ -300,8 +311,10 @@ func RenderStack(stackPath, provisionsDir, servicesDir string, valuesOverlay map
 
 	logger.Info().
 		Str(log.FieldOperation, "render_stack").
+		Str(log.FieldPath, stackPath).
 		Int("service_count", len(stack.Include)).
-		Msg("Stack rendering completed")
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Successfully rendered stack")
 
 	return output, nil
 }
@@ -310,13 +323,21 @@ func RenderStack(stackPath, provisionsDir, servicesDir string, valuesOverlay map
 // Iterates registered targets in sorted order for reproducible output.
 // Unregistered targets are logged as warnings and skipped.
 func WriteOutputs(output *RenderOutput, outputDir, stackName string) error {
+	start := time.Now()
 	logger := log.Component(log.ComponentManifest)
+	logger.Debug().
+		Str(log.FieldPath, outputDir).
+		Str("stack", stackName).
+		Int("target_count", len(output.Targets)).
+		Msg("Preparing to write manifest outputs")
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		logger.Error().Str(log.FieldPath, outputDir).Err(err).Msg("Failed to create output directory")
 		return fmt.Errorf("create output directory: %w", err)
 	}
 
 	// Write registered targets in sorted order
+	written := 0
 	for _, name := range TargetNames() {
 		cfg, registered := TargetRegistry[name]
 		if !registered {
@@ -326,6 +347,7 @@ func WriteOutputs(output *RenderOutput, outputDir, stackName string) error {
 		// Validate target directory stays within outputDir to prevent path traversal
 		targetDir, err := validatePathWithinDir(outputDir, cfg.Dir)
 		if err != nil {
+			logger.Error().Str("target", name).Err(err).Msg("Failed to validate target directory")
 			return fmt.Errorf("resolve %s directory: %w", name, err)
 		}
 
@@ -335,35 +357,48 @@ func WriteOutputs(output *RenderOutput, outputDir, stackName string) error {
 		if len(content) == 0 {
 			// Clean up stale file if the target is now empty
 			if err := os.Remove(outputPath); err == nil {
-				logger.Info().Str("target", name).Str(log.FieldPath, outputPath).Msg("Removed stale target file")
+				logger.Debug().Str("target", name).Str(log.FieldPath, outputPath).Msg("Removed stale target file")
 			}
 			continue
 		}
 
 		if err := os.MkdirAll(targetDir, 0755); err != nil {
+			logger.Error().Str("target", name).Str(log.FieldPath, targetDir).Err(err).Msg("Failed to create target directory")
 			return fmt.Errorf("create %s directory: %w", name, err)
 		}
 
 		data, err := yaml.Marshal(content)
 		if err != nil {
+			logger.Error().Str("target", name).Err(err).Msg("Failed to marshal target output")
 			return fmt.Errorf("marshal %s output: %w", name, err)
 		}
 
 		if err := os.WriteFile(outputPath, data, 0644); err != nil {
+			logger.Error().Str("target", name).Str(log.FieldPath, outputPath).Err(err).Msg("Failed to write target output file")
 			return fmt.Errorf("write %s output: %w", name, err)
 		}
 
+		logger.Debug().Str("target", name).Str(log.FieldPath, outputPath).Int("bytes", len(data)).Msg("Wrote target output file")
+		written++
 		fmt.Printf("Wrote: %s\n", outputPath)
 	}
 
 	// Warn about unregistered targets
+	unregistered := 0
 	for name := range output.Targets {
 		if _, registered := TargetRegistry[name]; !registered {
-			logger.Warn().
-				Str("target", name).
-				Msg("Skipping unregistered target in WriteOutputs")
+			logger.Warn().Str("target", name).Msg("Skipping unregistered target")
+			unregistered++
 		}
 	}
+
+	logger.Info().
+		Str(log.FieldPath, outputDir).
+		Str("stack", stackName).
+		Int("written", written).
+		Int("unregistered", unregistered).
+		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Msg("Successfully wrote manifest outputs")
 
 	return nil
 }
@@ -394,8 +429,12 @@ func RenderToYAML(output *RenderOutput) (string, error) {
 
 // LoadServiceManifest loads a service manifest from a file.
 func LoadServiceManifest(path string) (*ServiceManifest, error) {
+	logger := log.Component(log.ComponentManifest)
+	logger.Debug().Str(log.FieldPath, path).Msg("Loading service manifest")
+
 	content, err := os.ReadFile(path)
 	if err != nil {
+		logger.Error().Str(log.FieldPath, path).Err(err).Msg("Failed to read service manifest")
 		return nil, fmt.Errorf("read manifest: %w", err)
 	}
 
@@ -422,23 +461,31 @@ func LoadServiceManifest(path string) (*ServiceManifest, error) {
 
 	var manifest ServiceManifest
 	if err := yaml.Unmarshal(content, &manifest); err != nil {
+		logger.Error().Str(log.FieldPath, path).Err(err).Msg("Failed to parse service manifest")
 		return nil, fmt.Errorf("parse manifest: %w", err)
 	}
 
+	logger.Debug().Str(log.FieldPath, path).Str("service", manifest.Name).Msg("Successfully loaded service manifest")
 	return &manifest, nil
 }
 
 // LoadValuesOverlay loads a values overlay file.
 func LoadValuesOverlay(path string) (map[string]any, error) {
+	logger := log.Component(log.ComponentManifest)
+	logger.Debug().Str(log.FieldPath, path).Msg("Loading values overlay")
+
 	content, err := os.ReadFile(path)
 	if err != nil {
+		logger.Error().Str(log.FieldPath, path).Err(err).Msg("Failed to read values overlay file")
 		return nil, fmt.Errorf("read values file: %w", err)
 	}
 
 	var values map[string]any
 	if err := yaml.Unmarshal(content, &values); err != nil {
+		logger.Error().Str(log.FieldPath, path).Err(err).Msg("Failed to parse values overlay file")
 		return nil, fmt.Errorf("parse values file: %w", err)
 	}
 
+	logger.Debug().Str(log.FieldPath, path).Int("value_count", len(values)).Msg("Successfully loaded values overlay")
 	return values, nil
 }

--- a/internal/manifest/render.go
+++ b/internal/manifest/render.go
@@ -313,7 +313,7 @@ func RenderStack(stackPath, provisionsDir, servicesDir string, valuesOverlay map
 		Str(log.FieldOperation, "render_stack").
 		Str(log.FieldPath, stackPath).
 		Int("service_count", len(stack.Include)).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Successfully rendered stack")
 
 	return output, nil
@@ -397,7 +397,7 @@ func WriteOutputs(output *RenderOutput, outputDir, stackName string) error {
 		Str("stack", stackName).
 		Int("written", written).
 		Int("unregistered", unregistered).
-		Int64(log.FieldDurationMS, time.Since(start).Milliseconds()).
+		Int64(log.FieldDurationMS, log.DurationMS(start)).
 		Msg("Successfully wrote manifest outputs")
 
 	return nil


### PR DESCRIPTION
## Summary

Instruments the `docker` and `manifest` packages with action-oriented **narrative
logging** (Before/Success/Failure), following the project's existing conventions
(`log.Component`/`log.ComponentCtx`, `FieldDurationMS`, `FieldPath`, `FieldContainer`,
the `ComponentDocker`/`ComponentManifest` constants).

This was a complete, uncommitted instrumentation pass found in the working tree;
it's purely additive (+267/−8), changes no behavior, and is committed as-is after
verification.

### What's logged

- **`internal/docker/`** — `Ping`, `CountContainers`, `GetContainerByName`,
  `ListContainers`, and compose `Up` gain debug/info/warn/error lines with duration
  timings.
- **`internal/manifest/`** — provision load/list, stack render, and interpolation
  failures.
- **`.gitignore`** — ignore `.claude/intros/`.

## Verification

`go test ./internal/docker/ ./internal/manifest/` ✅ · `go build ./...` ✅. No
behavior change, so no new tests.

## Coordination note

This touches `docker/client.go` `Ping`, which **bosun-kn1** (Tier-3 docker context
fixes) will also edit (deadline-shadowing + ctx-ignoring `io.Copy` drains). Landing
this first keeps that follow-up a clean rebase rather than a conflict.

Refs bosun-ixv

🤖 Generated with [Claude Code](https://claude.com/claude-code)