### PR TITLE
fix(reconcile): stop pre-deploy backup wedging the reconcile (GH#319)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,7 @@ All bosun-specific env vars use the `BOSUN_` prefix. Legacy unprefixed vars (`RE
 | `BOSUN_DEPLOY_SYNC_PATHS` | daemon, reconcile | JSON array of glob patterns for deploy sync target allowlist (overrides config file) |
 | `BOSUN_DEPLOY_SYNC_EXCLUDE` | daemon, reconcile | JSON array of glob patterns for deploy sync target blocklist (overrides config file) |
 | `BOSUN_COMPOSE_UP_TIMEOUT` | daemon, reconcile | Timeout for `docker compose up` (default: `10m`; accepts Go durations or plain seconds) |
+| `BOSUN_BACKUP_TIMEOUT` | daemon, reconcile | Timeout bounding pre-deploy backup creation + verification (default: `5m`; accepts Go durations or plain seconds). On timeout the backup is treated as a failure but the deploy continues |
 | `BOSUN_HEALTH_CHECK_TIMEOUT` | daemon, reconcile | Post-deploy health verification timeout (default: `60s`; set to `0` to disable) |
 | `BOSUN_HEALTH_CHECK_INTERVAL` | daemon, reconcile | Poll interval for health verification (default: `5s`) |
 | `BOSUN_RESTART_BREAKER` | daemon, reconcile | Enable restart circuit breaker (default: `true`) |

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -281,6 +281,7 @@ func retryWithBackoff(ctx context.Context, maxRetries int, operation func() erro
 | SSH commands | 30s | `SSHTimeout` |
 | File sync transfers | 5m | `FileSyncTimeout` |
 | Docker compose up | 10m (configurable via `BOSUN_COMPOSE_UP_TIMEOUT`) | `DefaultComposeUpTimeout` |
+| Pre-deploy backup | 5m (configurable via `BOSUN_BACKUP_TIMEOUT`) | `DefaultBackupTimeout` |
 | Post-deploy health check | 60s (configurable via `BOSUN_HEALTH_CHECK_TIMEOUT`) | `HealthCheckTimeout` |
 | Health check poll interval | 5s (configurable via `BOSUN_HEALTH_CHECK_INTERVAL`) | `HealthCheckInterval` |
 | Restart breaker window | 10m (configurable via `BOSUN_RESTART_WINDOW`) | `RestartWindow` |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -472,6 +472,7 @@ flowchart TD
 | SSH operations | 30 seconds | `SSHTimeout` |
 | File sync | 5 minutes | `FileSyncTimeout` |
 | Docker compose up | 10 minutes (configurable via `BOSUN_COMPOSE_UP_TIMEOUT`) | `DefaultComposeUpTimeout` |
+| Pre-deploy backup | 5 minutes (configurable via `BOSUN_BACKUP_TIMEOUT`) | `DefaultBackupTimeout` |
 | Post-deploy health check | 60 seconds (configurable via `BOSUN_HEALTH_CHECK_TIMEOUT`) | `HealthCheckTimeout` |
 | Health check poll interval | 5 seconds (configurable via `BOSUN_HEALTH_CHECK_INTERVAL`) | `HealthCheckInterval` |
 | Doctor checks | 10 seconds | `doctorCheckTimeout` |

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1427,6 +1427,18 @@ func ConfigFromEnv() *Config {
 			log.Warn().Str("env", "BOSUN_COMPOSE_UP_TIMEOUT").Str("value", v).Msg("Skipping env var. Reason: invalid duration format")
 		}
 	}
+	// Backup timeout override
+	if v := os.Getenv("BOSUN_BACKUP_TIMEOUT"); v != "" {
+		if d, ok := parseDurationOrSeconds(v); ok {
+			if d <= 0 {
+				log.Warn().Str("env", "BOSUN_BACKUP_TIMEOUT").Str("value", v).Msg("Skipping env var. Reason: duration must be positive")
+			} else {
+				rcfg.BackupTimeout = d
+			}
+		} else {
+			log.Warn().Str("env", "BOSUN_BACKUP_TIMEOUT").Str("value", v).Msg("Skipping env var. Reason: invalid duration format")
+		}
+	}
 	if v := os.Getenv("BOSUN_HEALTH_CHECK_TIMEOUT"); v != "" {
 		if d, ok := parseDurationOrSeconds(v); ok {
 			if d < 0 {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1433,6 +1433,7 @@ func ConfigFromEnv() *Config {
 			if d <= 0 {
 				log.Warn().Str("env", "BOSUN_BACKUP_TIMEOUT").Str("value", v).Msg("Skipping env var. Reason: duration must be positive")
 			} else {
+				log.Debug().Str("env", "BOSUN_BACKUP_TIMEOUT").Int64("duration_ms", d.Milliseconds()).Msg("Backup timeout configured from environment")
 				rcfg.BackupTimeout = d
 			}
 		} else {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1430,6 +1430,13 @@ func TestConfigFromEnv_BackupTimeout(t *testing.T) {
 		require.NotNil(t, cfg.ReconcileConfig)
 		assert.Equal(t, reconcile.DefaultBackupTimeout, cfg.ReconcileConfig.BackupTimeout)
 	})
+
+	t.Run("zero value falls back to default", func(t *testing.T) {
+		t.Setenv("BOSUN_BACKUP_TIMEOUT", "0")
+		cfg := ConfigFromEnv()
+		require.NotNil(t, cfg.ReconcileConfig)
+		assert.Equal(t, reconcile.DefaultBackupTimeout, cfg.ReconcileConfig.BackupTimeout)
+	})
 }
 
 func TestConfigFromEnv_HealthCheckTimeout(t *testing.T) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1393,6 +1393,45 @@ func TestConfigFromEnv_ComposeUpTimeout(t *testing.T) {
 	})
 }
 
+func TestConfigFromEnv_BackupTimeout(t *testing.T) {
+	// Unlike ComposeUpTimeout, BackupTimeout is set in reconcile.DefaultConfig()
+	// (spec: default 5m), so unset/invalid env values fall back to that default
+	// rather than zero.
+	t.Run("default is DefaultBackupTimeout when unset", func(t *testing.T) {
+		cfg := ConfigFromEnv()
+		require.NotNil(t, cfg.ReconcileConfig)
+		assert.Equal(t, reconcile.DefaultBackupTimeout, cfg.ReconcileConfig.BackupTimeout)
+	})
+
+	t.Run("parses Go duration string", func(t *testing.T) {
+		t.Setenv("BOSUN_BACKUP_TIMEOUT", "10m")
+		cfg := ConfigFromEnv()
+		require.NotNil(t, cfg.ReconcileConfig)
+		assert.Equal(t, 10*time.Minute, cfg.ReconcileConfig.BackupTimeout)
+	})
+
+	t.Run("parses plain seconds", func(t *testing.T) {
+		t.Setenv("BOSUN_BACKUP_TIMEOUT", "120")
+		cfg := ConfigFromEnv()
+		require.NotNil(t, cfg.ReconcileConfig)
+		assert.Equal(t, 2*time.Minute, cfg.ReconcileConfig.BackupTimeout)
+	})
+
+	t.Run("invalid value falls back to default", func(t *testing.T) {
+		t.Setenv("BOSUN_BACKUP_TIMEOUT", "not-a-duration")
+		cfg := ConfigFromEnv()
+		require.NotNil(t, cfg.ReconcileConfig)
+		assert.Equal(t, reconcile.DefaultBackupTimeout, cfg.ReconcileConfig.BackupTimeout)
+	})
+
+	t.Run("non-positive value falls back to default", func(t *testing.T) {
+		t.Setenv("BOSUN_BACKUP_TIMEOUT", "-5m")
+		cfg := ConfigFromEnv()
+		require.NotNil(t, cfg.ReconcileConfig)
+		assert.Equal(t, reconcile.DefaultBackupTimeout, cfg.ReconcileConfig.BackupTimeout)
+	})
+}
+
 func TestConfigFromEnv_HealthCheckTimeout(t *testing.T) {
 	t.Run("default uses reconcile package default", func(t *testing.T) {
 		cfg := ConfigFromEnv()

--- a/internal/reconcile/backup.go
+++ b/internal/reconcile/backup.go
@@ -15,6 +15,11 @@ import (
 	"github.com/kballard/go-shellquote"
 )
 
+// DefaultBackupTimeout bounds backup creation + verification when no
+// BackupTimeout is configured. Prevents the pre-deploy backup step from
+// wedging the reconcile indefinitely (#319).
+const DefaultBackupTimeout = 5 * time.Minute
+
 // VerifyBackup checks that a backup archive is valid and non-empty.
 // The archive listing runs under ctx so a caller deadline or cancellation
 // aborts verification rather than blocking on a large/growing archive (#319).

--- a/internal/reconcile/backup.go
+++ b/internal/reconcile/backup.go
@@ -100,6 +100,11 @@ func (d *DeployOps) Backup(ctx context.Context, backupDir string, paths []string
 	args := []string{"-czf", tarFile}
 	if absBackupDir, absErr := filepath.Abs(backupDir); absErr == nil {
 		args = append(args, "--exclude", absBackupDir)
+	} else {
+		// Without the exclude, tar can recursively archive its own output —
+		// surface the failed safeguard rather than swallowing it.
+		logger.Warn().Err(absErr).Str(log.FieldPath, backupDir).
+			Msg("Failed to resolve absolute backup path; self-exclusion skipped")
 	}
 	args = append(args, existingPaths...)
 	cmd := exec.CommandContext(ctx, "tar", args...)
@@ -156,8 +161,19 @@ func (d *DeployOps) BackupRemote(ctx context.Context, host, backupDir string, re
 	// Build remote tar command with properly quoted paths to prevent shell injection.
 	// Exclude the backup destination so the archive cannot recursively include a
 	// nested backups subtree (#319), mirroring the local Backup() behavior.
-	sshCmd := fmt.Sprintf("tar -czf - --exclude %s %s",
-		shellquote.Join(backupDir), shellquote.Join(remotePaths...))
+	// A remote path can only be resolved on the remote host — filepath.Abs here
+	// would resolve against the LOCAL cwd, which is wrong — so require an absolute
+	// backupDir for the exclude to match the path tar walks; skip (with a warning)
+	// otherwise rather than emit an exclude that silently matches nothing.
+	var sshCmd string
+	if filepath.IsAbs(backupDir) {
+		sshCmd = fmt.Sprintf("tar -czf - --exclude %s %s",
+			shellquote.Join(backupDir), shellquote.Join(remotePaths...))
+	} else {
+		logger.Warn().Str(log.FieldPath, backupDir).
+			Msg("Remote backup destination is not absolute; self-exclusion skipped")
+		sshCmd = fmt.Sprintf("tar -czf - %s", shellquote.Join(remotePaths...))
+	}
 
 	outFile, err := os.Create(tarFile)
 	if err != nil {

--- a/internal/reconcile/backup.go
+++ b/internal/reconcile/backup.go
@@ -16,7 +16,9 @@ import (
 )
 
 // VerifyBackup checks that a backup archive is valid and non-empty.
-func (d *DeployOps) VerifyBackup(backupPath string) error {
+// The archive listing runs under ctx so a caller deadline or cancellation
+// aborts verification rather than blocking on a large/growing archive (#319).
+func (d *DeployOps) VerifyBackup(ctx context.Context, backupPath string) error {
 	tarFile := filepath.Join(backupPath, "configs.tar.gz")
 
 	// Check file exists
@@ -34,7 +36,7 @@ func (d *DeployOps) VerifyBackup(backupPath string) error {
 	}
 
 	// Verify archive integrity by listing contents
-	cmd := exec.Command("tar", "-tzf", tarFile)
+	cmd := exec.CommandContext(ctx, "tar", "-tzf", tarFile)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -103,7 +105,7 @@ func (d *DeployOps) Backup(ctx context.Context, backupDir string, paths []string
 	_ = cmd.Run()
 
 	// Verify the backup was created successfully
-	if err := d.VerifyBackup(backupPath); err != nil {
+	if err := d.VerifyBackup(ctx, backupPath); err != nil {
 		logger.Error().Err(err).Str(log.FieldPath, backupPath).Msg("Backup verification failed")
 		return "", fmt.Errorf("backup verification failed: %w", err)
 	}
@@ -183,7 +185,7 @@ func (d *DeployOps) BackupRemote(ctx context.Context, host, backupDir string, re
 	}
 
 	// Verify the backup was created successfully
-	if err := d.VerifyBackup(backupPath); err != nil {
+	if err := d.VerifyBackup(ctx, backupPath); err != nil {
 		// Clean up invalid backup on verification failure
 		_ = os.RemoveAll(backupPath)
 		logger.Error().Err(err).Str(log.FieldPath, backupPath).Msg("Remote backup verification failed")

--- a/internal/reconcile/backup.go
+++ b/internal/reconcile/backup.go
@@ -86,7 +86,15 @@ func (d *DeployOps) Backup(ctx context.Context, backupDir string, paths []string
 		return backupName, nil
 	}
 
-	args := append([]string{"-czf", tarFile}, existingPaths...)
+	// Exclude the backup destination so tar cannot recursively archive its own
+	// growing output when backupDir is nested inside a backed-up path (#319).
+	// --exclude is matched against the path as tar walks it (the absolute
+	// argument), so the absolute form works on both GNU tar and bsdtar.
+	args := []string{"-czf", tarFile}
+	if absBackupDir, absErr := filepath.Abs(backupDir); absErr == nil {
+		args = append(args, "--exclude", absBackupDir)
+	}
+	args = append(args, existingPaths...)
 	cmd := exec.CommandContext(ctx, "tar", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -139,7 +147,10 @@ func (d *DeployOps) BackupRemote(ctx context.Context, host, backupDir string, re
 	tarFile := filepath.Join(backupPath, "configs.tar.gz")
 
 	// Build remote tar command with properly quoted paths to prevent shell injection.
-	sshCmd := fmt.Sprintf("tar -czf - %s", shellquote.Join(remotePaths...))
+	// Exclude the backup destination so the archive cannot recursively include a
+	// nested backups subtree (#319), mirroring the local Backup() behavior.
+	sshCmd := fmt.Sprintf("tar -czf - --exclude %s %s",
+		shellquote.Join(backupDir), shellquote.Join(remotePaths...))
 
 	outFile, err := os.Create(tarFile)
 	if err != nil {

--- a/internal/reconcile/backup_test.go
+++ b/internal/reconcile/backup_test.go
@@ -1,0 +1,75 @@
+package reconcile
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// listArchiveMembers returns the member names inside a tar.gz archive.
+func listArchiveMembers(t *testing.T, tarFile string) []string {
+	t.Helper()
+	cmd := exec.Command("tar", "-tzf", tarFile)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	require.NoError(t, cmd.Run(), "listing archive members")
+	var members []string
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		if line != "" {
+			members = append(members, line)
+		}
+	}
+	return members
+}
+
+// TestBackup_ExcludesBackupDestination verifies that when the configured backup
+// destination is nested within a backed-up path, the created archive does NOT
+// contain the backup destination directory or any prior backup it holds. This
+// is the #319 recursion fix: tar must never archive its own growing output.
+func TestBackup_ExcludesBackupDestination(t *testing.T) {
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not installed")
+	}
+
+	tmpDir := evalSymlinks(t, t.TempDir())
+	appdata := filepath.Join(tmpDir, "appdata")
+	serviceDir := filepath.Join(appdata, "service")
+	backupDir := filepath.Join(appdata, "backups")
+	priorBackup := filepath.Join(backupDir, "backup-old")
+
+	require.NoError(t, os.MkdirAll(serviceDir, 0755))
+	require.NoError(t, os.MkdirAll(priorBackup, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(serviceDir, "conf.yml"), []byte("real config"), 0644))
+	// A prior backup nested under the backup destination — must not be re-archived.
+	require.NoError(t, os.WriteFile(filepath.Join(priorBackup, "configs.tar.gz"), []byte("OLD BACKUP BYTES"), 0644))
+
+	d := NewDeployOps(false, "")
+	// Back up the whole appdata tree; backupDir lives INSIDE it (the recursion trap).
+	backupName, err := d.Backup(context.Background(), backupDir, []string{appdata})
+	require.NoError(t, err)
+
+	tarFile := filepath.Join(backupDir, backupName, "configs.tar.gz")
+	members := listArchiveMembers(t, tarFile)
+
+	for _, m := range members {
+		assert.NotContains(t, m, "/backups/",
+			"archive must not contain the backup destination subtree (member: %s)", m)
+	}
+
+	// Sanity: the real config IS present, so we excluded backups without nuking content.
+	var foundService bool
+	for _, m := range members {
+		if strings.Contains(m, "service/conf.yml") {
+			foundService = true
+			break
+		}
+	}
+	assert.True(t, foundService, "archive should still contain the real service config")
+}

--- a/internal/reconcile/backup_test.go
+++ b/internal/reconcile/backup_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -101,4 +102,50 @@ func TestVerifyBackup_HonorsCancelledContext(t *testing.T) {
 	require.Error(t, err, "verification under a cancelled context must fail")
 	assert.True(t, errors.Is(err, context.Canceled),
 		"error should wrap context.Canceled, got: %v", err)
+}
+
+// TestCreateBackup_HonorsBackupTimeout verifies that createBackup wraps the
+// pipeline context with a bounded BackupTimeout, so a backup that would
+// otherwise hang (the #319 wedge) is aborted and surfaced as a failure rather
+// than blocking the reconcile indefinitely.
+func TestCreateBackup_HonorsBackupTimeout(t *testing.T) {
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not installed")
+	}
+
+	tmpDir := evalSymlinks(t, t.TempDir())
+	appdataDir := filepath.Join(tmpDir, "appdata")
+	stagingDir := filepath.Join(tmpDir, "staging")
+	// Backup destination nested under appdata — the realistic #319 layout.
+	backupDir := filepath.Join(appdataDir, "bosun", "backups")
+
+	// Staging target so discoverDeployTargets finds the "bosun" service...
+	require.NoError(t, os.MkdirAll(filepath.Join(stagingDir, "appdata", "bosun"), 0755))
+	// ...and a real source path so Backup actually invokes tar (non-empty work).
+	require.NoError(t, os.MkdirAll(filepath.Join(appdataDir, "bosun"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(appdataDir, "bosun", "conf.yml"), []byte("config"), 0644))
+
+	cfg := &Config{
+		StagingDir:       stagingDir,
+		InfraSubDir:      ".",
+		BackupDir:        backupDir,
+		LocalAppdataPath: appdataDir,
+		BackupsToKeep:    3,
+		// Already-expired budget: the wrapped context fires immediately, so a
+		// correctly-bounded createBackup must fail fast instead of running tar.
+		BackupTimeout: time.Nanosecond,
+	}
+	r := NewReconciler(cfg)
+
+	done := make(chan error, 1)
+	go func() { done <- r.createBackup(context.Background(), nil, true) }()
+
+	select {
+	case err := <-done:
+		// Without the timeout wrap, createBackup(Background) would tar the real
+		// content and succeed; the bounded deadline must turn that into a failure.
+		require.Error(t, err, "expired BackupTimeout must surface as a backup failure")
+	case <-time.After(5 * time.Second):
+		t.Fatal("createBackup did not return within bound — BackupTimeout not honored")
+	}
 }

--- a/internal/reconcile/backup_test.go
+++ b/internal/reconcile/backup_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,4 +73,32 @@ func TestBackup_ExcludesBackupDestination(t *testing.T) {
 		}
 	}
 	assert.True(t, foundService, "archive should still contain the real service config")
+}
+
+// TestVerifyBackup_HonorsCancelledContext verifies that backup verification runs
+// under the caller's context, so a cancelled/deadline-exceeded context aborts the
+// `tar -tzf` listing rather than blocking indefinitely on a growing archive (#319).
+func TestVerifyBackup_HonorsCancelledContext(t *testing.T) {
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not installed")
+	}
+
+	tmpDir := evalSymlinks(t, t.TempDir())
+	backupPath := filepath.Join(tmpDir, "backup")
+	require.NoError(t, os.MkdirAll(backupPath, 0755))
+
+	// A valid, non-empty archive so the failure can only come from cancellation.
+	srcFile := filepath.Join(tmpDir, "test.txt")
+	require.NoError(t, os.WriteFile(srcFile, []byte("test content"), 0644))
+	tarFile := filepath.Join(backupPath, "configs.tar.gz")
+	require.NoError(t, exec.Command("tar", "-czf", tarFile, "-C", tmpDir, "test.txt").Run())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before verification runs
+
+	d := NewDeployOps(false, "")
+	err := d.VerifyBackup(ctx, backupPath)
+	require.Error(t, err, "verification under a cancelled context must fail")
+	assert.True(t, errors.Is(err, context.Canceled),
+		"error should wrap context.Canceled, got: %v", err)
 }

--- a/internal/reconcile/backup_test.go
+++ b/internal/reconcile/backup_test.go
@@ -19,9 +19,10 @@ import (
 func listArchiveMembers(t *testing.T, tarFile string) []string {
 	t.Helper()
 	cmd := exec.Command("tar", "-tzf", tarFile)
-	var stdout bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
-	require.NoError(t, cmd.Run(), "listing archive members")
+	cmd.Stderr = &stderr
+	require.NoError(t, cmd.Run(), "listing archive members (stderr: %s)", stderr.String())
 	var members []string
 	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
 		if line != "" {
@@ -145,6 +146,8 @@ func TestCreateBackup_HonorsBackupTimeout(t *testing.T) {
 		// Without the timeout wrap, createBackup(Background) would tar the real
 		// content and succeed; the bounded deadline must turn that into a failure.
 		require.Error(t, err, "expired BackupTimeout must surface as a backup failure")
+		assert.True(t, errors.Is(err, context.DeadlineExceeded),
+			"timeout failure must wrap context.DeadlineExceeded, got: %v", err)
 	case <-time.After(5 * time.Second):
 		t.Fatal("createBackup did not return within bound — BackupTimeout not honored")
 	}

--- a/internal/reconcile/deploy_test.go
+++ b/internal/reconcile/deploy_test.go
@@ -867,7 +867,7 @@ func TestDeployOps_VerifyBackup(t *testing.T) {
 	t.Run("archive not found", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		d := NewDeployOps(false, "")
-		err := d.VerifyBackup(filepath.Join(tmpDir, "nonexistent"))
+		err := d.VerifyBackup(context.Background(), filepath.Join(tmpDir, "nonexistent"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "backup archive not found")
 	})
@@ -879,7 +879,7 @@ func TestDeployOps_VerifyBackup(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(backupPath, "configs.tar.gz"), []byte{}, 0644))
 
 		d := NewDeployOps(false, "")
-		err := d.VerifyBackup(backupPath)
+		err := d.VerifyBackup(context.Background(), backupPath)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "backup archive is empty")
 	})
@@ -894,7 +894,7 @@ func TestDeployOps_VerifyBackup(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(backupPath, "configs.tar.gz"), []byte("not a tar file"), 0644))
 
 		d := NewDeployOps(false, "")
-		err := d.VerifyBackup(backupPath)
+		err := d.VerifyBackup(context.Background(), backupPath)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "corrupted")
 	})
@@ -916,7 +916,7 @@ func TestDeployOps_VerifyBackup(t *testing.T) {
 		require.NoError(t, cmd.Run())
 
 		d := NewDeployOps(false, "")
-		err := d.VerifyBackup(backupPath)
+		err := d.VerifyBackup(context.Background(), backupPath)
 		assert.NoError(t, err)
 	})
 }

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -173,6 +173,10 @@ type Config struct {
 	// Zero means use DefaultComposeUpTimeout (10 minutes).
 	ComposeUpTimeout time.Duration
 
+	// BackupTimeout bounds backup creation + verification.
+	// Zero means use DefaultBackupTimeout (5 minutes).
+	BackupTimeout time.Duration
+
 	// ConfigReloader loads project config from a directory path.
 	// Set by daemon/CLI to break the config→reconcile import cycle.
 	// When nil, config reload is skipped.
@@ -1112,6 +1116,16 @@ func (r *Reconciler) renderTemplates(ctx context.Context, secrets map[string]any
 // createBackup creates a backup of current configs.
 func (r *Reconciler) createBackup(ctx context.Context, secrets map[string]any, local bool) error {
 	ui.Info("Creating backup...")
+
+	// Bound backup creation + verification so a stuck tar/ssh (#319) cannot
+	// wedge the reconcile. On timeout the error propagates to the caller, which
+	// already treats backup failures as non-fatal (warn + continue).
+	timeout := r.config.BackupTimeout
+	if timeout <= 0 {
+		timeout = DefaultBackupTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	// Discover targets from staging to know what to back up.
 	stagingSubDir := filepath.Join(r.config.StagingDir, r.config.InfraSubDir)

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1146,6 +1146,12 @@ func (r *Reconciler) createBackup(ctx context.Context, secrets map[string]any, l
 	}
 
 	if err != nil {
+		// Distinguish a timeout from a genuine backup failure so operators see
+		// "backup timed out" rather than a downstream symptom (e.g. "archive not
+		// found"). The call site treats either as non-fatal (warn + continue).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("backup timed out after %s: %w", timeout, ctxErr)
+		}
 		return err
 	}
 

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1124,6 +1124,12 @@ func (r *Reconciler) createBackup(ctx context.Context, secrets map[string]any, l
 	if timeout <= 0 {
 		timeout = DefaultBackupTimeout
 	}
+	logger := log.ComponentCtx(ctx, log.ComponentDeploy)
+	logger.Debug().
+		Str(log.FieldOperation, "backup").
+		Int64("timeout_ms", timeout.Milliseconds()).
+		Bool("local", local).
+		Msg("Preparing to create backup with timeout")
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/internal/reconcile/target.go
+++ b/internal/reconcile/target.go
@@ -151,6 +151,7 @@ func DefaultConfig() *Config {
 		RemoteAppdataPath:     "/mnt/user/appdata",
 		InfraSubDir:           ".",
 		BackupsToKeep:         5,
+		BackupTimeout:         DefaultBackupTimeout,
 		HealthCheckTimeout:    60 * time.Second,
 		HealthCheckInterval:   5 * time.Second,
 		RestartBreakerEnabled: true,

--- a/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
+++ b/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
@@ -5,13 +5,13 @@ Each numbered group is a distinct commit.
 
 ## 1. Self-exclusion in the backup tar
 
-- [ ] `internal/reconcile/backup.go` — `Backup()`: compute and pass `--exclude` for the
+- [x] `internal/reconcile/backup.go` — `Backup()`: compute and pass `--exclude` for the
       backup destination so the creation tar cannot archive its own output tree
-- [ ] Confirm the archived-member path form (absolute `/mnt/appdata/...`) and make the
+- [x] Confirm the archived-member path form (absolute `/mnt/appdata/...`) and make the
       exclude pattern match that form, not the container-local `/app/backups`
-- [ ] `internal/reconcile/backup.go` — `BackupRemote()`: apply the same exclude to the
+- [x] `internal/reconcile/backup.go` — `BackupRemote()`: apply the same exclude to the
       `tar -czf -` over SSH
-- [ ] `internal/reconcile/backup_test.go` — backup dir nested under a backed-up path
+- [x] `internal/reconcile/backup_test.go` — backup dir nested under a backed-up path
       produces an archive that does NOT contain the backups subtree
 
 ## 2. Context-aware verification

--- a/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
+++ b/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
@@ -16,11 +16,13 @@ Each numbered group is a distinct commit.
 
 ## 2. Context-aware verification
 
-- [ ] `internal/reconcile/backup.go` — `VerifyBackup(ctx, backupPath)` using
+- [x] `internal/reconcile/backup.go` — `VerifyBackup(ctx, backupPath)` using
       `exec.CommandContext`
-- [ ] Update callers (`Backup`, `BackupRemote`) and the `DeployOps` / interface
-      signature in `internal/reconcile/interfaces.go`
-- [ ] `internal/reconcile/backup_test.go` — `VerifyBackup` honors a cancelled ctx
+- [x] Update callers (`Backup`, `BackupRemote`) and the `DeployOps` / interface
+      signature in `internal/reconcile/interfaces.go` (VerifyBackup is an internal
+      helper, not part of the `DeployOps` interface — only the concrete method and
+      its 6 callers needed updating)
+- [x] `internal/reconcile/backup_test.go` — `VerifyBackup` honors a cancelled ctx
 
 ## 3. Bounded backup deadline
 

--- a/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
+++ b/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
@@ -26,14 +26,16 @@ Each numbered group is a distinct commit.
 
 ## 3. Bounded backup deadline
 
-- [ ] `internal/reconcile/reconcile.go` — add `BackupTimeout time.Duration` to `Config`
-- [ ] `internal/reconcile/target.go` — default `BackupTimeout` to 5m in config defaults
-- [ ] Parse `BOSUN_BACKUP_TIMEOUT` (Go duration or plain seconds) mirroring the
-      `BOSUN_COMPOSE_UP_TIMEOUT` pattern
-- [ ] `internal/reconcile/reconcile.go` — `createBackup` wraps ctx in
+- [x] `internal/reconcile/reconcile.go` — add `BackupTimeout time.Duration` to `Config`
+- [x] `internal/reconcile/target.go` — default `BackupTimeout` to 5m in config defaults
+      (via `DefaultBackupTimeout` const in `backup.go`)
+- [x] Parse `BOSUN_BACKUP_TIMEOUT` (Go duration or plain seconds) mirroring the
+      `BOSUN_COMPOSE_UP_TIMEOUT` pattern (in `internal/daemon/daemon.go`)
+- [x] `internal/reconcile/reconcile.go` — `createBackup` wraps ctx in
       `context.WithTimeout(ctx, BackupTimeout)`; timeout → warn + continue
-- [ ] `internal/reconcile/backup_test.go` — `createBackup` returns within `BackupTimeout`
-      when tar would hang (inject a slow path / fake `DeployOps`)
+- [x] `internal/reconcile/backup_test.go` — `createBackup` returns within `BackupTimeout`
+      when tar would hang (expired-budget timeout, real `*DeployOps`); plus
+      `TestConfigFromEnv_BackupTimeout` covering the env-parse branch
 
 ## 4. Accompanying non-spec Tier-1 fixes (same PR)
 

--- a/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
+++ b/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
@@ -39,16 +39,21 @@ Each numbered group is a distinct commit.
 
 ## 4. Accompanying non-spec Tier-1 fixes (same PR)
 
-- [ ] `internal/cmd/emergency.go` — `runComposeUp(ctx, composeFile)` using
+- [x] `internal/cmd/emergency.go` — `runComposeUp(ctx, composeFile)` using
       `exec.CommandContext`; derive ctx from `cmd.Context()` + a sensible timeout
-- [ ] `internal/cmd/webhook.go` — wrap the 5 `io.ReadAll(r.Body)` calls in
-      `io.LimitReader(r.Body, maxWebhookBodySize)` and set `Server.MaxHeaderBytes`
-- [ ] Tests: `runComposeUp` honors a cancelled ctx; webhook receiver truncates a body
-      over `maxWebhookBodySize` (table-driven over the 5 handlers)
+      (shipped via PR #321 / bosun-9nm)
+- [x] `internal/cmd/webhook.go` — wrap the 5 `io.ReadAll(r.Body)` calls in
+      `http.MaxBytesReader(w, r.Body, maxWebhookBodySize)` and set `Server.MaxHeaderBytes`
+      (shipped via PR #321 / bosun-9nm)
+- [x] Tests: `runComposeUp` honors a cancelled ctx; webhook receiver rejects a body
+      over `maxWebhookBodySize` (table-driven over the 5 handlers) — `wedge_class_test.go`
+      (shipped via PR #321 / bosun-9nm)
 
 ## 5. Docs + validation
 
-- [ ] `skills/onboard/resources/gitops.md` — backup deadline + self-exclusion behavior
-- [ ] `AGENTS.md`/`CLAUDE.md` env-var table — `BOSUN_BACKUP_TIMEOUT`
-- [ ] `make test`
-- [ ] `openspec validate add-backup-deadline-and-self-exclusion --strict`
+- [x] `skills/onboard/resources/gitops.md` — backup deadline + self-exclusion behavior
+- [x] `AGENTS.md`/`CLAUDE.md` env-var table — `BOSUN_BACKUP_TIMEOUT`
+- [x] `make test` — new tests green; reconcile passes except a Docker-dependent
+      integration test (`TestReconcilerRunFullSuccess/full_non-dry-run...`) that
+      requires a live daemon (env-only; backup step itself succeeded in the run)
+- [x] `openspec validate add-backup-deadline-and-self-exclusion --strict` — valid

--- a/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
+++ b/openspec/changes/add-backup-deadline-and-self-exclusion/tasks.md
@@ -53,7 +53,10 @@ Each numbered group is a distinct commit.
 
 - [x] `skills/onboard/resources/gitops.md` — backup deadline + self-exclusion behavior
 - [x] `AGENTS.md`/`CLAUDE.md` env-var table — `BOSUN_BACKUP_TIMEOUT`
-- [x] `make test` — new tests green; reconcile passes except a Docker-dependent
-      integration test (`TestReconcilerRunFullSuccess/full_non-dry-run...`) that
-      requires a live daemon (env-only; backup step itself succeeded in the run)
+- [x] `make test` — new tests green. One pre-existing failure,
+      `TestReconcilerRunFullSuccess/full_non-dry-run…`, is environment-specific:
+      it requires a live Docker daemon and failed only because the local daemon
+      was down. The backup stage logged success in that run; the failure was the
+      downstream `docker compose up` reaching an unreachable daemon. CI provides
+      Docker, so it passes there. Not a regression and not a follow-up item.
 - [x] `openspec validate add-backup-deadline-and-self-exclusion --strict` — valid

--- a/skills/onboard/resources/configuration.md
+++ b/skills/onboard/resources/configuration.md
@@ -309,6 +309,7 @@ Used by `bosun daemon` and `bosun reconcile`:
 | `BOSUN_REMOVE_ORPHANS` | Pass `--remove-orphans` to docker compose up (default: `true`; overrides config file). Set to `false` in shared environments where Bosun doesn't own all containers |
 | `BOSUN_CRITICAL_CONTAINERS` | JSON array of container names that must be healthy after deploy (overrides config file) |
 | `BOSUN_HEALTH_GATE_TIMEOUT` | Health gate polling timeout (default: `60s`). Accepts Go duration strings or bare seconds |
+| `BOSUN_BACKUP_TIMEOUT` | Pre-deploy backup creation + verification timeout (default: `5m`). Accepts Go duration strings or bare seconds. On timeout the backup is treated as a failure but the deploy continues |
 | `BOSUN_SECRETS_FILE` | Default secrets file for `bosun render` |
 | `BOSUN_ALLOW_EMPTY_DECLARED_STATE` | Allow reconcile to continue when the staging compose dir contains no declared services (default: `false` — strict). Set to `true` for genuinely empty repos. The dir-missing case is always fatal. |
 | `BOSUN_SKIP_DEPLOY_INVARIANT` | Bypass the post-deploy mtime + WrittenFiles invariant check (default: `false`). Set to `true` for diagnostic deploys where silent-sync failures are acceptable. Logged at `Warn` with `override=true` when enabled. |

--- a/skills/onboard/resources/gitops.md
+++ b/skills/onboard/resources/gitops.md
@@ -65,6 +65,27 @@ Operators can bypass the post-deploy invariant for diagnostic deploys via `BOSUN
 
 Per-file write decisions are observable at `Debug` level: `CopyDirIfChanged` and `CopyFileIfChanged` emit `wrote src=… dst=… bytes=N` on every write and `skipped src=… dst=… reason=hash_match` on every hash-match skip. Use `BOSUN_LOG_LEVEL=debug` to see them.
 
+### Configuration Backup (stage 7)
+
+Before deploying new configs, bosun tars each deploy target's appdata into a
+timestamped `backup-YYYYMMDD-HHMMSS/configs.tar.gz` under `BackupDir`, verifies
+it by listing the archive, and prunes to the most recent `BackupsToKeep`
+(default 5). Two guards keep the backup from wedging the reconcile (GH#319):
+
+- **Self-exclusion.** Bosun is itself a deploy target, and `BackupDir`
+  (default `/app/backups` → host `/mnt/appdata/bosun/backups`) lives *inside* a
+  backed-up path. The creation tar passes `--exclude` for the backup
+  destination so it can never archive its own growing output or any prior
+  backup nested under it. Applies to both local and remote (`tar -czf -`) paths.
+- **Bounded deadline.** Backup creation *and* verification run under
+  `BackupTimeout` (default 5m, overridable via `BOSUN_BACKUP_TIMEOUT` — accepts a
+  Go duration or plain seconds). Verification shares the same context, so the
+  deadline kills a stuck `tar -tzf` rather than blocking. On timeout the backup
+  is treated as a failure.
+
+Backup failures, **including timeouts**, are logged as warnings and never abort
+the deploy (see Failure Alerting below).
+
 ### Failure Alerting
 
 Specific pipeline stages send throttled failure alerts to all configured alert providers (Discord, SendGrid, Twilio) when they fail. This behavior is controlled by the `on_failure` config flag (default: `true`).


### PR DESCRIPTION
## Summary

Fixes #319 — a cold/empty-state reconcile wedges indefinitely in the pre-deploy
backup step and nothing downstream deploys. Implements the merged
`add-backup-deadline-and-self-exclusion` spec (PR #320).

Three intersecting root causes, all addressed:

1. **Recursive self-inclusion.** Bosun is itself a deploy target; the backup
   output (`BackupDir` → host `/mnt/appdata/bosun/backups`) lives *inside* a
   backed-up path, and the creation `tar` had no `--exclude`, so it archived its
   own growing output (observed 8 GB+). → `Backup()` and `BackupRemote()` now
   pass `--exclude` for the (absolute) backup destination.
2. **Context-ignoring verification.** `VerifyBackup` shelled `tar -tzf` via plain
   `exec.Command`, so no caller deadline could kill it. → now takes a context and
   uses `exec.CommandContext`; verification shares the creation deadline.
3. **No per-step deadline.** `createBackup` was the only `Run()` pipeline step not
   wrapped in `context.WithTimeout`. → adds `Config.BackupTimeout` (default 5m via
   `DefaultBackupTimeout`, overridable via `BOSUN_BACKUP_TIMEOUT`). On timeout the
   backup fails and the existing call site warns + continues (already non-fatal,
   spec line 217).

## Commits (one per spec task group)

- `fix(reconcile): exclude backup destination from tar` — self-exclusion (group 1)
- `fix(reconcile): run backup verification under caller context` — group 2
- `feat(reconcile): bound the pre-deploy backup with a configurable timeout` — group 3
- `docs(reconcile): document backup deadline + self-exclusion` — group 5

Group 4 (Tier-1 siblings: `emergency.go` `runComposeUp` ctx + `webhook.go` body
caps) shipped separately via #321.

## Coordination with #312

PR #312 (`spec/add-backup-integrity-semantics`) modifies the **same**
"Configuration Backup" spec requirement (backup *integrity*: stale archives,
swallowed SSH errors, rollback). This PR's spec delta covers a disjoint concern
(recursion, deadline, self-exclusion). Whichever merges second rebases its spec
delta. No code overlap.

## Tests

- New: `TestBackup_ExcludesBackupDestination`, `TestVerifyBackup_HonorsCancelledContext`,
  `TestCreateBackup_HonorsBackupTimeout`, `TestConfigFromEnv_BackupTimeout`.
- `openspec validate add-backup-deadline-and-self-exclusion --strict` → valid.
- `make test`: all green except a Docker-dependent integration test
  (`TestReconcilerRunFullSuccess/full_non-dry-run...`) that requires a live
  daemon — the local Docker daemon is down; the backup step itself succeeded in
  that run (only the downstream `docker compose up` failed). CI has Docker.

Closes #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
