### PR TITLE
ci(spec-review): validate changed change-dirs from diff, not branch name

### DIFF
--- a/.github/workflows/spec-review.yml
+++ b/.github/workflows/spec-review.yml
@@ -37,20 +37,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install OpenSpec
         run: npm install -g @fission-ai/openspec
 
-      - name: Extract change ID from branch
+      - name: Determine changed change IDs
         id: change-id
         env:
+          BASE_REF: ${{ github.base_ref }}
           BRANCH: ${{ github.head_ref }}
         run: |
-          CHANGE_ID="${BRANCH#spec/}"
-          echo "id=$CHANGE_ID" >> "$GITHUB_OUTPUT"
-          echo "Validating change: $CHANGE_ID"
+          # Derive change IDs from the dirs the PR actually touches under
+          # openspec/changes/<id>/, not from the branch name. The branch-name
+          # convention breaks for fold/refactor PRs whose branch (e.g.
+          # spec/fold-cluster-c-multitarget) differs from the change dir they
+          # edit (add-multi-target-reconcile). (bosun-6wu)
+          git fetch --no-tags origin "$BASE_REF"
+          BASE_SHA="$(git rev-parse "origin/$BASE_REF")"
+          mapfile -t ids < <(git diff --name-only "$BASE_SHA...HEAD" \
+            | sed -nE 's#^openspec/changes/([^/]+)/.*#\1#p' \
+            | grep -vx archive \
+            | sort -u)
+          if [ ${#ids[@]} -eq 0 ]; then
+            # Fall back to the branch-name convention for net-new proposals.
+            ids=("${BRANCH#spec/}")
+            echo "No changed change-dirs in diff; falling back to branch name: ${ids[*]}"
+          fi
+          echo "Validating change(s): ${ids[*]}"
+          echo "ids=${ids[*]}" >> "$GITHUB_OUTPUT"
 
       - name: Validate spec
         env:
-          CHANGE_ID: ${{ steps.change-id.outputs.id }}
-        run: openspec validate "$CHANGE_ID" --strict
+          IDS: ${{ steps.change-id.outputs.ids }}
+        run: |
+          rc=0
+          for id in $IDS; do
+            echo "::group::openspec validate $id --strict"
+            openspec validate "$id" --strict || rc=1
+            echo "::endgroup::"
+          done
+          exit "$rc"


### PR DESCRIPTION
## Why

The Spec Review Gate's **Validate Spec** job derived the change ID from the branch name (`CHANGE_ID="${BRANCH#spec/}"`), assuming branch name == change ID. That breaks for fold/refactor spec PRs: #313's branch `spec/fold-cluster-c-multitarget` edits the existing change `add-multi-target-reconcile`, so CI ran `openspec validate fold-cluster-c-multitarget --strict` → `Unknown item` → failure, even though the real change validated locally. (#313 had to be merged past that false-negative red check.)

## What

- Derive change IDs from the dirs the PR actually touches under `openspec/changes/<id>/` (via `base..HEAD` diff) instead of the branch name.
- Validate **each** changed change-dir (supports multi-change PRs).
- Fall back to the branch-name convention only when the diff yields no change-dirs (net-new proposals still work).
- Add `fetch-depth: 0` so the diff has a base to compute against.

## Safety

Untrusted refs (`github.base_ref`, `github.head_ref`) are passed via `env:` and only referenced as quoted shell variables — never interpolated inline into `run:`.

## Verification

- `actionlint` (incl. shellcheck on `run:` blocks): clean.
- Extraction logic yields `add-multi-target-reconcile` from #313's paths and ignores non-change paths.
- Validate loop passes against a real on-main change (`openspec validate add-backup-integrity-semantics --strict` → rc 0).

Closes bosun-6wu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)