### PR TITLE
fix(reconcile): no-op content-hash sync no longer trips empty-write invariant (#330)

### DIFF
--- a/docs/adr/0013-deploy-sync-invariant-gates.md
+++ b/docs/adr/0013-deploy-sync-invariant-gates.md
@@ -41,6 +41,14 @@ Future gates SHOULD follow this template:
 - Tests cover: each sentinel triggers the right error, the override bypasses (when applicable), boundary conditions where strict equality matters
 - Per-file `Debug` log at gate entry so operators tracing a deploy see the gate firing
 
+### Amendment — GH#330 (empty-write gate refinement)
+
+The `ErrDeployInvariantEmptyWrite` gate originally treated **any** zero-write deploy target with a non-empty source as a failure, on the assumption that "source has files but nothing was written" is the silent-sync signature. This was too aggressive: with content-hash sync, a target legitimately records zero writes when the destination already byte-matches the source. [GH#330](https://github.com/cameronsjo/bosun/issues/330) is the resulting outage — a single byte-identical config (`dnscrypt-proxy.toml`) tripped the gate and aborted the entire reconcile before `docker compose up`, taking down 62 containers.
+
+The gate now **inspects the destination** instead of inferring from the write count: on zero writes against a non-empty source it verifies each source file exists at the destination. All present → legitimate no-op, pass. Any missing → genuine silent-sync failure, fire `ErrDeployInvariantEmptyWrite` (the error now carries a `missing=…` field naming the first absent file). This preserves the gate's protective value — it still catches "files should be on disk but aren't" — while removing the false positive. The reframing also strengthens the gate: it asserts the post-condition (files present at destination) directly rather than via the `WrittenFiles` proxy.
+
+This is consistent with the original "fail loud, but only on genuine absence of work" intent; the bug was conflating "no write this run" with "no file on disk."
+
 ## Consequences
 
 ### Pros

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,7 +55,7 @@ The render step produced no parseable services in `<staging>/compose/`. Either t
 
 **Invariant 2 — `deploy invariant: source has files but no writes recorded` / `destination file has stale mtime`**
 
-The deploy sync step claimed success but either wrote nothing against a non-empty source or the destination's mtime is older than the reconcile start. This is the GH#214 silent-success signature — content-hash sync may have matched against stale destination content, or the write path silently failed.
+The deploy sync step claimed success but the destination doesn't reflect it. Two shapes trip this: (1) a written file's mtime is older than the reconcile start, or (2) zero files were written against a non-empty source **and a source file is missing from the destination**. Both are the GH#214 silent-sync signature — the write path silently failed. Note: a zero-write target whose destination already content-matches the source is a legitimate no-op and does **not** fail (fixed in GH#330); the error fires only when a file is genuinely absent. The `missing=…` field in the error names the first absent file.
 
 To debug:
 

--- a/internal/reconcile/verify.go
+++ b/internal/reconcile/verify.go
@@ -36,14 +36,32 @@ func verifyDeployTarget(src, dst string, writtenRel []string, startTime time.Tim
 			logger.Error().Err(err).Str(log.FieldPath, src).Msg("Failed to verify deploy target. Reason: cannot inspect source")
 			return fmt.Errorf("inspect source %q: %w", src, err)
 		}
-		if hasFiles {
+		if !hasFiles {
+			logger.Debug().Msg("Deploy target verification passed: empty source and no files written")
+			return nil
+		}
+		// Source has files but the sync recorded zero writes. With content-hash
+		// sync this is the legitimate no-op case: the destination already
+		// byte-matches the source, so CopyDirIfChanged correctly skipped every
+		// file (GH#330). Distinguish that from a genuine silent-sync failure by
+		// inspecting the destination — existence only, no mtime check, since the
+		// files were written on a prior run. Fail only when files are missing.
+		missing, err := firstMissingSourceFile(src, dst)
+		if err != nil {
+			logger.Error().Err(err).Str(log.FieldPath, dst).Msg("Failed to verify deploy target. Reason: cannot inspect destination")
+			return fmt.Errorf("inspect destination %q: %w", dst, err)
+		}
+		if missing != "" {
 			logger.Error().
 				Str(log.FieldPath, src).
 				Str("destination", dst).
-				Msg("Failed to verify deploy target. Reason: empty write recorded against non-empty source")
-			return fmt.Errorf("%w: src=%q dst=%q", ErrDeployInvariantEmptyWrite, src, dst)
+				Str("missing", missing).
+				Msg("Failed to verify deploy target. Reason: source file missing from destination after zero-write sync")
+			return fmt.Errorf("%w: src=%q dst=%q missing=%q", ErrDeployInvariantEmptyWrite, src, dst, missing)
 		}
-		logger.Debug().Msg("Deploy target verification passed: empty source and no files written")
+		logger.Debug().
+			Str("destination", dst).
+			Msg("Deploy target verification passed: no-op sync, destination already content-matches source")
 		return nil
 	}
 
@@ -78,6 +96,61 @@ func verifyDeployTarget(src, dst string, writtenRel []string, startTime time.Tim
 
 	logger.Info().Int("written_count", len(writtenRel)).Msg("Successfully verified deploy target invariant")
 	return nil
+}
+
+// firstMissingSourceFile reports the first regular file under src that has no
+// counterpart at dst, or "" if every source file is present. It mirrors how
+// the deploy maps source files onto the destination: a directory source maps
+// each file to its same relative path under dst; a single-file source maps to
+// dst/<basename>. Only existence is checked — callers use this for the no-op
+// (zero-write) sync case, where matching files were written on a prior run and
+// therefore carry old mtimes. A missing source is treated as "nothing missing".
+func firstMissingSourceFile(src, dst string) (string, error) {
+	info, err := os.Stat(src)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	if !info.IsDir() {
+		target := filepath.Join(dst, filepath.Base(src))
+		if _, err := os.Stat(target); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return target, nil
+			}
+			return "", err
+		}
+		return "", nil
+	}
+
+	var missing string
+	walkErr := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		target := filepath.Join(dst, rel)
+		if _, statErr := os.Stat(target); statErr != nil {
+			if errors.Is(statErr, fs.ErrNotExist) {
+				missing = target
+				return fs.SkipAll
+			}
+			return statErr
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return "", walkErr
+	}
+	return missing, nil
 }
 
 // dirHasRegularFiles reports whether src is, or recursively contains, at

--- a/internal/reconcile/verify_test.go
+++ b/internal/reconcile/verify_test.go
@@ -37,79 +37,107 @@ func TestVerifyDeployTarget_HealthyDeploy_Passes(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestVerifyDeployTarget_EmptyWrittenFiles_Against_NonEmptySource_Errors(t *testing.T) {
-	// #214 silent-sync failure: source has files, zero writes recorded, AND the
-	// destination is genuinely missing those files (render produced nothing, or
-	// the write was dropped). This is a real failure and must abort. Contrast
-	// with the no-op case (GH#330), where the destination already content-matches
-	// the source — see TestVerifyDeployTarget_NoOpSync_*.
-	dir := t.TempDir()
-	src := filepath.Join(dir, "src")
-	dst := filepath.Join(dir, "dst")
-	startTime := time.Now().Add(-1 * time.Minute)
-
-	touchFile(t, filepath.Join(src, "compose.yml"), "services:\n  foo: {}\n", time.Now())
-	require.NoError(t, os.MkdirAll(dst, 0755)) // dst exists but is empty — file missing.
-
-	err := verifyDeployTarget(src, dst, nil, startTime)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrDeployInvariantEmptyWrite)
-	assert.Contains(t, err.Error(), "src=")
-	assert.Contains(t, err.Error(), "dst=")
-}
-
-func TestVerifyDeployTarget_NoOpSync_DestinationMatches_Passes(t *testing.T) {
-	// GH#330: content-hash sync wrote 0 files because the destination already
-	// byte-matches the source. The files exist at dst (written on a prior run,
-	// so their mtime predates startTime). This is a legitimate no-op, not a
-	// silent failure, and must pass.
-	dir := t.TempDir()
-	src := filepath.Join(dir, "src")
-	dst := filepath.Join(dir, "dst")
-	startTime := time.Now().Add(-1 * time.Minute)
-
-	staleTime := time.Now().Add(-30 * 24 * time.Hour)
-	touchFile(t, filepath.Join(src, "dnscrypt-proxy.toml"), "server_names = []\n", staleTime)
-	touchFile(t, filepath.Join(dst, "dnscrypt-proxy.toml"), "server_names = []\n", staleTime)
-
-	err := verifyDeployTarget(src, dst, nil, startTime)
-	assert.NoError(t, err, "no-op sync against a content-matched destination must pass")
-}
-
-func TestVerifyDeployTarget_NoOpSync_NestedFiles_Passes(t *testing.T) {
-	// The no-op check must walk nested source files, not just the top level.
-	dir := t.TempDir()
-	src := filepath.Join(dir, "src")
-	dst := filepath.Join(dir, "dst")
-	startTime := time.Now().Add(-1 * time.Minute)
-
+// TestVerifyDeployTarget_ZeroWriteScenarios covers the invariant's empty-writes
+// branch: when a sync records no writes against a non-empty source, the gate
+// inspects the destination directly. A destination that already content-matches
+// the source is a legitimate no-op (GH#330) and passes; a destination missing
+// any source file is a #214 silent-sync failure and errors. setup builds the
+// source/destination trees and returns the (src, dst) pair passed to the gate —
+// dst is the destination directory for directory sources and the parent
+// directory for single-file sources, matching how reconcile.go calls it.
+func TestVerifyDeployTarget_ZeroWriteScenarios(t *testing.T) {
 	stale := time.Now().Add(-7 * 24 * time.Hour)
-	touchFile(t, filepath.Join(src, "top.yml"), "a", stale)
-	touchFile(t, filepath.Join(src, "sub", "nested.yml"), "b", stale)
-	touchFile(t, filepath.Join(dst, "top.yml"), "a", stale)
-	touchFile(t, filepath.Join(dst, "sub", "nested.yml"), "b", stale)
 
-	err := verifyDeployTarget(src, dst, nil, startTime)
-	assert.NoError(t, err)
-}
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, dir string) (src, dst string)
+		wantErr     bool
+		errContains []string
+	}{
+		{
+			name: "dir source, destination content-matches → no-op passes",
+			setup: func(t *testing.T, dir string) (string, string) {
+				src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+				touchFile(t, filepath.Join(src, "dnscrypt-proxy.toml"), "server_names = []\n", stale)
+				touchFile(t, filepath.Join(dst, "dnscrypt-proxy.toml"), "server_names = []\n", stale)
+				return src, dst
+			},
+		},
+		{
+			name: "dir source, nested files match → no-op passes",
+			setup: func(t *testing.T, dir string) (string, string) {
+				src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+				touchFile(t, filepath.Join(src, "top.yml"), "a", stale)
+				touchFile(t, filepath.Join(src, "sub", "nested.yml"), "b", stale)
+				touchFile(t, filepath.Join(dst, "top.yml"), "a", stale)
+				touchFile(t, filepath.Join(dst, "sub", "nested.yml"), "b", stale)
+				return src, dst
+			},
+		},
+		{
+			name: "dir source, destination empty → silent failure errors",
+			setup: func(t *testing.T, dir string) (string, string) {
+				src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+				touchFile(t, filepath.Join(src, "compose.yml"), "services:\n  foo: {}\n", time.Now())
+				require.NoError(t, os.MkdirAll(dst, 0755)) // exists but empty — file missing.
+				return src, dst
+			},
+			wantErr:     true,
+			errContains: []string{"src=", "dst=", "compose.yml"},
+		},
+		{
+			name: "dir source, one file missing → silent failure errors",
+			setup: func(t *testing.T, dir string) (string, string) {
+				src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+				touchFile(t, filepath.Join(src, "present.yml"), "a", stale)
+				touchFile(t, filepath.Join(src, "absent.yml"), "b", stale)
+				touchFile(t, filepath.Join(dst, "present.yml"), "a", stale) // absent.yml NOT at dst.
+				return src, dst
+			},
+			wantErr:     true,
+			errContains: []string{"absent.yml"},
+		},
+		{
+			name: "file source, destination matches → no-op passes",
+			setup: func(t *testing.T, dir string) (string, string) {
+				srcFile := filepath.Join(dir, "src", "single.yml")
+				dstDir := filepath.Join(dir, "dst")
+				touchFile(t, srcFile, "v1", stale)
+				touchFile(t, filepath.Join(dstDir, "single.yml"), "v1", stale)
+				return srcFile, dstDir // dst is the parent dir for file targets.
+			},
+		},
+		{
+			name: "file source, destination empty → silent failure errors",
+			setup: func(t *testing.T, dir string) (string, string) {
+				srcFile := filepath.Join(dir, "src", "single.yml")
+				dstDir := filepath.Join(dir, "dst")
+				touchFile(t, srcFile, "v1", stale)
+				require.NoError(t, os.MkdirAll(dstDir, 0755))
+				return srcFile, dstDir
+			},
+			wantErr:     true,
+			errContains: []string{"single.yml"},
+		},
+	}
 
-func TestVerifyDeployTarget_NoOpSync_PartiallyMissingDestination_Errors(t *testing.T) {
-	// Zero writes but only some source files exist at dst — a genuine silent
-	// failure hiding behind the no-op signature. The invariant must still fire.
-	dir := t.TempDir()
-	src := filepath.Join(dir, "src")
-	dst := filepath.Join(dir, "dst")
-	startTime := time.Now().Add(-1 * time.Minute)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src, dst := tt.setup(t, t.TempDir())
+			startTime := time.Now().Add(-1 * time.Minute)
 
-	stale := time.Now().Add(-7 * 24 * time.Hour)
-	touchFile(t, filepath.Join(src, "present.yml"), "a", stale)
-	touchFile(t, filepath.Join(src, "absent.yml"), "b", stale)
-	touchFile(t, filepath.Join(dst, "present.yml"), "a", stale) // absent.yml NOT at dst.
-
-	err := verifyDeployTarget(src, dst, nil, startTime)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrDeployInvariantEmptyWrite)
-	assert.Contains(t, err.Error(), "absent.yml")
+			err := verifyDeployTarget(src, dst, nil, startTime)
+			if !tt.wantErr {
+				assert.NoError(t, err, "zero-write sync against a content-matched destination must pass")
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrDeployInvariantEmptyWrite)
+			for _, want := range tt.errContains {
+				assert.Contains(t, err.Error(), want)
+			}
+		})
+	}
 }
 
 func TestVerifyDeployTarget_EmptyWrittenFiles_Against_EmptySource_Passes(t *testing.T) {
@@ -237,37 +265,69 @@ func TestVerifyDeployTarget_SrcIsRegularFile_HealthyPasses(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestVerifyDeployTarget_SrcIsRegularFile_EmptyWritten_Errors(t *testing.T) {
-	// Single-file source, zero writes, destination dir empty — the file never
-	// landed. Genuine silent failure, must error.
-	dir := t.TempDir()
-	srcFile := filepath.Join(dir, "src", "single.yml")
-	dstDir := filepath.Join(dir, "dst")
+// TestFirstMissingSourceFile exercises the helper directly, including branches
+// verifyDeployTarget cannot reach (a missing source short-circuits earlier via
+// dirHasRegularFiles) and the stat-error path.
+func TestFirstMissingSourceFile(t *testing.T) {
+	t.Run("missing source returns nothing missing", func(t *testing.T) {
+		dir := t.TempDir()
+		missing, err := firstMissingSourceFile(filepath.Join(dir, "nope"), dir)
+		require.NoError(t, err)
+		assert.Empty(t, missing)
+	})
 
-	touchFile(t, srcFile, "v1", time.Now())
-	require.NoError(t, os.MkdirAll(dstDir, 0755))
+	t.Run("dir source all present returns empty", func(t *testing.T) {
+		dir := t.TempDir()
+		src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+		touchFile(t, filepath.Join(src, "a.yml"), "a", time.Now())
+		touchFile(t, filepath.Join(dst, "a.yml"), "a", time.Now())
+		missing, err := firstMissingSourceFile(src, dst)
+		require.NoError(t, err)
+		assert.Empty(t, missing)
+	})
 
-	startTime := time.Now().Add(-1 * time.Minute)
-	err := verifyDeployTarget(srcFile, dstDir, nil, startTime)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrDeployInvariantEmptyWrite)
-}
+	t.Run("dir source missing file returns its destination path", func(t *testing.T) {
+		dir := t.TempDir()
+		src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+		touchFile(t, filepath.Join(src, "a.yml"), "a", time.Now())
+		require.NoError(t, os.MkdirAll(dst, 0755))
+		missing, err := firstMissingSourceFile(src, dst)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(dst, "a.yml"), missing)
+	})
 
-func TestVerifyDeployTarget_SrcIsRegularFile_NoOpSync_Passes(t *testing.T) {
-	// GH#330, single-file flavor: zero writes because the destination file
-	// already matches. dst is the parent dir (matching how reconcile.go calls
-	// verify for file targets) and contains the file. Must pass.
-	dir := t.TempDir()
-	srcFile := filepath.Join(dir, "src", "single.yml")
-	dstDir := filepath.Join(dir, "dst")
+	t.Run("file source present returns empty, absent returns path", func(t *testing.T) {
+		dir := t.TempDir()
+		srcFile := filepath.Join(dir, "single.yml")
+		touchFile(t, srcFile, "v", time.Now())
+		dstWith := filepath.Join(dir, "with")
+		touchFile(t, filepath.Join(dstWith, "single.yml"), "v", time.Now())
 
-	stale := time.Now().Add(-7 * 24 * time.Hour)
-	touchFile(t, srcFile, "v1", stale)
-	touchFile(t, filepath.Join(dstDir, "single.yml"), "v1", stale)
+		missing, err := firstMissingSourceFile(srcFile, dstWith)
+		require.NoError(t, err)
+		assert.Empty(t, missing)
 
-	startTime := time.Now().Add(-1 * time.Minute)
-	err := verifyDeployTarget(srcFile, dstDir, nil, startTime)
-	assert.NoError(t, err)
+		dstWithout := filepath.Join(dir, "without")
+		require.NoError(t, os.MkdirAll(dstWithout, 0755))
+		missing, err = firstMissingSourceFile(srcFile, dstWithout)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(dstWithout, "single.yml"), missing)
+	})
+
+	t.Run("unreadable source subtree surfaces stat error", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("running as root bypasses directory permissions")
+		}
+		dir := t.TempDir()
+		src := filepath.Join(dir, "src")
+		touchFile(t, filepath.Join(src, "sub", "a.yml"), "a", time.Now())
+		// Make the subdir untraversable so WalkDir's child walk errors.
+		require.NoError(t, os.Chmod(filepath.Join(src, "sub"), 0000))
+		t.Cleanup(func() { _ = os.Chmod(filepath.Join(src, "sub"), 0755) })
+
+		_, err := firstMissingSourceFile(src, filepath.Join(dir, "dst"))
+		require.Error(t, err)
+	})
 }
 
 func TestDirHasRegularFiles(t *testing.T) {

--- a/internal/reconcile/verify_test.go
+++ b/internal/reconcile/verify_test.go
@@ -38,22 +38,78 @@ func TestVerifyDeployTarget_HealthyDeploy_Passes(t *testing.T) {
 }
 
 func TestVerifyDeployTarget_EmptyWrittenFiles_Against_NonEmptySource_Errors(t *testing.T) {
-	// Layer 1.3, #214: this is the silent-success signature — source has files
-	// but CopyDirIfChanged returned no writes. Either render produced nothing
-	// useful or hashes matched stale destination content. Either way, fail.
+	// #214 silent-sync failure: source has files, zero writes recorded, AND the
+	// destination is genuinely missing those files (render produced nothing, or
+	// the write was dropped). This is a real failure and must abort. Contrast
+	// with the no-op case (GH#330), where the destination already content-matches
+	// the source — see TestVerifyDeployTarget_NoOpSync_*.
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src")
 	dst := filepath.Join(dir, "dst")
 	startTime := time.Now().Add(-1 * time.Minute)
 
 	touchFile(t, filepath.Join(src, "compose.yml"), "services:\n  foo: {}\n", time.Now())
-	require.NoError(t, os.MkdirAll(dst, 0755))
+	require.NoError(t, os.MkdirAll(dst, 0755)) // dst exists but is empty — file missing.
 
 	err := verifyDeployTarget(src, dst, nil, startTime)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrDeployInvariantEmptyWrite)
 	assert.Contains(t, err.Error(), "src=")
 	assert.Contains(t, err.Error(), "dst=")
+}
+
+func TestVerifyDeployTarget_NoOpSync_DestinationMatches_Passes(t *testing.T) {
+	// GH#330: content-hash sync wrote 0 files because the destination already
+	// byte-matches the source. The files exist at dst (written on a prior run,
+	// so their mtime predates startTime). This is a legitimate no-op, not a
+	// silent failure, and must pass.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	startTime := time.Now().Add(-1 * time.Minute)
+
+	staleTime := time.Now().Add(-30 * 24 * time.Hour)
+	touchFile(t, filepath.Join(src, "dnscrypt-proxy.toml"), "server_names = []\n", staleTime)
+	touchFile(t, filepath.Join(dst, "dnscrypt-proxy.toml"), "server_names = []\n", staleTime)
+
+	err := verifyDeployTarget(src, dst, nil, startTime)
+	assert.NoError(t, err, "no-op sync against a content-matched destination must pass")
+}
+
+func TestVerifyDeployTarget_NoOpSync_NestedFiles_Passes(t *testing.T) {
+	// The no-op check must walk nested source files, not just the top level.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	startTime := time.Now().Add(-1 * time.Minute)
+
+	stale := time.Now().Add(-7 * 24 * time.Hour)
+	touchFile(t, filepath.Join(src, "top.yml"), "a", stale)
+	touchFile(t, filepath.Join(src, "sub", "nested.yml"), "b", stale)
+	touchFile(t, filepath.Join(dst, "top.yml"), "a", stale)
+	touchFile(t, filepath.Join(dst, "sub", "nested.yml"), "b", stale)
+
+	err := verifyDeployTarget(src, dst, nil, startTime)
+	assert.NoError(t, err)
+}
+
+func TestVerifyDeployTarget_NoOpSync_PartiallyMissingDestination_Errors(t *testing.T) {
+	// Zero writes but only some source files exist at dst — a genuine silent
+	// failure hiding behind the no-op signature. The invariant must still fire.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	startTime := time.Now().Add(-1 * time.Minute)
+
+	stale := time.Now().Add(-7 * 24 * time.Hour)
+	touchFile(t, filepath.Join(src, "present.yml"), "a", stale)
+	touchFile(t, filepath.Join(src, "absent.yml"), "b", stale)
+	touchFile(t, filepath.Join(dst, "present.yml"), "a", stale) // absent.yml NOT at dst.
+
+	err := verifyDeployTarget(src, dst, nil, startTime)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDeployInvariantEmptyWrite)
+	assert.Contains(t, err.Error(), "absent.yml")
 }
 
 func TestVerifyDeployTarget_EmptyWrittenFiles_Against_EmptySource_Passes(t *testing.T) {
@@ -182,6 +238,8 @@ func TestVerifyDeployTarget_SrcIsRegularFile_HealthyPasses(t *testing.T) {
 }
 
 func TestVerifyDeployTarget_SrcIsRegularFile_EmptyWritten_Errors(t *testing.T) {
+	// Single-file source, zero writes, destination dir empty — the file never
+	// landed. Genuine silent failure, must error.
 	dir := t.TempDir()
 	srcFile := filepath.Join(dir, "src", "single.yml")
 	dstDir := filepath.Join(dir, "dst")
@@ -193,6 +251,23 @@ func TestVerifyDeployTarget_SrcIsRegularFile_EmptyWritten_Errors(t *testing.T) {
 	err := verifyDeployTarget(srcFile, dstDir, nil, startTime)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrDeployInvariantEmptyWrite)
+}
+
+func TestVerifyDeployTarget_SrcIsRegularFile_NoOpSync_Passes(t *testing.T) {
+	// GH#330, single-file flavor: zero writes because the destination file
+	// already matches. dst is the parent dir (matching how reconcile.go calls
+	// verify for file targets) and contains the file. Must pass.
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "src", "single.yml")
+	dstDir := filepath.Join(dir, "dst")
+
+	stale := time.Now().Add(-7 * 24 * time.Hour)
+	touchFile(t, srcFile, "v1", stale)
+	touchFile(t, filepath.Join(dstDir, "single.yml"), "v1", stale)
+
+	startTime := time.Now().Add(-1 * time.Minute)
+	err := verifyDeployTarget(srcFile, dstDir, nil, startTime)
+	assert.NoError(t, err)
 }
 
 func TestDirHasRegularFiles(t *testing.T) {
@@ -315,10 +390,13 @@ func newDeployLocalDeploy() *DeployOps {
 	}
 }
 
-// silentSyncReproduction is the GH#214 shape: src and dst contain identical
-// bytes, so CopyDirIfChanged hashes the two and records zero writes despite
-// the deploy "succeeding."
-func TestDeployLocal_SilentEmptyWrite_FailsInvariant(t *testing.T) {
+// TestDeployLocal_NoOpSync_PassesInvariant is the GH#330 shape: staging and
+// appdata contain identical bytes, so CopyDirIfChanged hashes the two and
+// records zero writes. The destination already content-matches the source, so
+// this is a legitimate no-op and the deploy must succeed — not abort on the
+// empty-write invariant. (Previously this exact scenario was asserted to fail
+// under #214's overly aggressive invariant, which caused the GH#330 outage.)
+func TestDeployLocal_NoOpSync_PassesInvariant(t *testing.T) {
 	fx := newDeployLocalFixture(t)
 	now := time.Now()
 	touchFile(t, filepath.Join(fx.freshrssStaging, "config.yml"), "identical", now)
@@ -333,9 +411,9 @@ func TestDeployLocal_SilentEmptyWrite_FailsInvariant(t *testing.T) {
 	}
 	r := NewReconciler(cfg, WithDeployOps(newDeployLocalDeploy()))
 
-	_, err := r.deployLocal(context.Background(), nil)
-	require.Error(t, err, "deployLocal should fail when sync writes nothing against a non-empty source")
-	assert.ErrorIs(t, err, ErrDeployInvariantEmptyWrite)
+	result, err := r.deployLocal(context.Background(), nil)
+	require.NoError(t, err, "a no-op sync against a content-matched destination must not trip the invariant")
+	assert.NotNil(t, result)
 }
 
 func TestDeployLocal_SkipDeployInvariant_BypassesCheck(t *testing.T) {

--- a/openspec/changes/add-deploy-sync-invariants/specs/reconcile/spec.md
+++ b/openspec/changes/add-deploy-sync-invariants/specs/reconcile/spec.md
@@ -15,7 +15,9 @@ The reconciler SHALL enforce three invariants between deploy sync (stage 8) and 
 
 **Invariant 2 — Written files exist with fresh mtime.** After deploy sync completes, for each path in `WrittenFiles` across all targets, the reconciler SHALL stat the destination path and assert `mtime >= reconcileStartTime`. If any destination is missing or stale, the reconciler SHALL fail before compose-up runs.
 
-**Invariant 3 — Non-empty source must produce written files.** For each deploy target whose source staging directory contains at least one regular file, the reconciler SHALL assert that the target's `WrittenFiles` slice is non-empty. An empty `WrittenFiles` against a non-empty source indicates the sync silently no-op'd, and SHALL fail the reconcile run.
+**Invariant 3 — Non-empty source must be reflected at the destination.** For each deploy target whose source staging directory contains at least one regular file but whose `WrittenFiles` slice is empty, the reconciler SHALL inspect the destination directly: it SHALL assert that every regular file in the source exists at its corresponding destination path (existence only — no mtime assertion, since a content-hash match means the files were written on a prior run). If every source file is present, the zero-write result is a legitimate no-op (the destination already byte-matches the source) and the invariant SHALL pass. If any source file is absent from the destination, the sync silently failed and the reconciler SHALL fail the run, naming the first missing file.
+
+This refines the original formulation, which failed *any* zero-write target against a non-empty source. That was too aggressive: with content-hash sync a target legitimately records zero writes when the destination already matches, so a single byte-identical config could abort an entire reconcile (see GH#330). Asserting the real post-condition — files present at the destination — preserves protection against silent-sync failures while permitting genuine no-ops.
 
 The invariant check (invariants 2 and 3) MAY be skipped via `BOSUN_SKIP_DEPLOY_INVARIANT=true` for diagnostic or development scenarios. When skipped, the reconciler SHALL log at `Warn` level noting that invariants are disabled.
 
@@ -51,13 +53,22 @@ Per-file write decisions SHALL be observable: `CopyDirIfChanged` and `CopyFileIf
 - **AND** compose up does not run
 - **AND** the error message names the stale destination path
 
-#### Scenario: Empty WrittenFiles against non-empty source blocks compose-up
+#### Scenario: No-op sync against a content-matched destination passes
 
 - **WHEN** a deploy target's source staging directory contains regular files
 - **AND** the target's `WrittenFiles` returned by `CopyDirIfChanged` is empty
+- **AND** every source file already exists at its corresponding destination path
+- **THEN** the invariant check passes at stage 9 (legitimate no-op — destination already byte-matches)
+- **AND** compose up proceeds normally
+
+#### Scenario: Empty WrittenFiles with a missing destination file blocks compose-up
+
+- **WHEN** a deploy target's source staging directory contains regular files
+- **AND** the target's `WrittenFiles` returned by `CopyDirIfChanged` is empty
+- **AND** at least one source file is absent from the destination
 - **THEN** the invariant check fails at stage 9
 - **AND** compose up does not run
-- **AND** the error message names the target whose sync produced no writes
+- **AND** the error message names the first source file missing from the destination
 
 #### Scenario: Healthy deploy passes invariant check
 

--- a/openspec/changes/add-deploy-sync-invariants/tasks.md
+++ b/openspec/changes/add-deploy-sync-invariants/tasks.md
@@ -28,7 +28,7 @@ Implementation runs in three layers. Layer 1 ships the invariants and observabil
 
 - [x] `internal/reconcile/verify.go` (new file) — `verifyDeployTarget(src, dst, writtenRel, startTime) error` helper
 - [x] `internal/reconcile/verify.go` — invariant: each `WrittenFiles` entry must exist at destination with `mtime >= startTime`
-- [x] `internal/reconcile/verify.go` — invariant: empty `WrittenFiles` against non-empty source is an error
+- [x] `internal/reconcile/verify.go` — invariant: empty `WrittenFiles` against non-empty source inspects the destination — passes on a content-matched no-op, errors (naming the missing file) when a source file is absent (refined per GH#330; `firstMissingSourceFile` helper)
 - [x] `internal/reconcile/reconcile.go` — call `verifyDeployTarget` per-target inside `deployLocal` before `PrefixLatest`
 - [x] `internal/daemon/daemon.go` — parse `BOSUN_SKIP_DEPLOY_INVARIANT` in `ConfigFromEnv()` (landed in Layer 1.2 commit alongside `BOSUN_ALLOW_EMPTY_DECLARED_STATE`)
 - [x] `internal/reconcile/verify_test.go` — `TestVerifyDeployTarget_StaleDestination_Errors`

--- a/openspec/changes/add-deploy-sync-invariants/tasks.md
+++ b/openspec/changes/add-deploy-sync-invariants/tasks.md
@@ -32,7 +32,7 @@ Implementation runs in three layers. Layer 1 ships the invariants and observabil
 - [x] `internal/reconcile/reconcile.go` — call `verifyDeployTarget` per-target inside `deployLocal` before `PrefixLatest`
 - [x] `internal/daemon/daemon.go` — parse `BOSUN_SKIP_DEPLOY_INVARIANT` in `ConfigFromEnv()` (landed in Layer 1.2 commit alongside `BOSUN_ALLOW_EMPTY_DECLARED_STATE`)
 - [x] `internal/reconcile/verify_test.go` — `TestVerifyDeployTarget_StaleDestination_Errors`
-- [x] `internal/reconcile/verify_test.go` — `TestVerifyDeployTarget_EmptyWrittenFiles_Against_NonEmptySource_Errors`
+- [x] `internal/reconcile/verify_test.go` — `TestVerifyDeployTarget_ZeroWriteScenarios` (table-driven: no-op passes, missing-file errors; refined per GH#330)
 - [x] `internal/reconcile/verify_test.go` — `TestDeployLocal_SkipDeployInvariant_BypassesCheck` (env wiring through `deployLocal`)
 - [x] `internal/reconcile/verify_test.go` — `TestVerifyDeployTarget_HealthyDeploy_Passes` + `TestDeployLocal_HealthyDeploy_PassesInvariant`
 

--- a/skills/onboard/resources/gitops.md
+++ b/skills/onboard/resources/gitops.md
@@ -34,8 +34,9 @@ Every reconciliation follows this 16-stage sequence:
  8. Deploy files (local copy or tar-over-SSH)
         |
  9. Verify deploy-sync invariants — every WrittenFiles entry must exist
-    with fresh mtime; empty WrittenFiles against non-empty source is an
-    error. Skipped if BOSUN_SKIP_DEPLOY_INVARIANT=true.
+    with fresh mtime; empty WrittenFiles against a non-empty source fails
+    only when the destination is missing those files (a no-op sync that
+    already matches passes). Skipped if BOSUN_SKIP_DEPLOY_INVARIANT=true.
         |
 10. Run docker compose up (per-file isolated, with rollback)
         |
@@ -59,7 +60,7 @@ Every reconciliation follows this 16-stage sequence:
 Bosun enforces two invariant gates that turn the GH#214 silent-success failure mode into a loud error:
 
 - **Declared-state invariant (stage 6)** — if `ExtractDeclaredState` returns `ErrComposeDirMissing` the reconcile fails unconditionally (no override). When the infra dir has no `compose/` but a sibling directory does, the error names the candidate and suggests the `BOSUN_INFRA_DIR` value to set (e.g. `did you mean BOSUN_INFRA_DIR=unraid?`) — the GH#214 misconfiguration. If it returns `ErrNoDeclaredServices` the reconcile fails unless `BOSUN_ALLOW_EMPTY_DECLARED_STATE=true` is set; the override logs at `Warn` level with `override=true`.
-- **Post-deploy invariant (stage 9)** — for every file in `DeployResult.WrittenFiles`, the destination must exist at `mtime >= reconcileStartTime`. If a deploy target's source staging dir contains regular files but the target's `WrittenFiles` is empty, that is the GH#214 silent-sync signature and fails the reconcile before `docker compose up` runs.
+- **Post-deploy invariant (stage 9)** — for every file in `DeployResult.WrittenFiles`, the destination must exist at `mtime >= reconcileStartTime`. When a deploy target records zero writes against a non-empty source, the gate inspects the destination directly: if every source file is already present it is a legitimate no-op sync (content-hash match) and passes; if any file is missing it is the GH#214 silent-sync failure and fails the reconcile before `docker compose up` runs. (The earlier behavior — treating *any* zero-write target as a failure — caused the GH#330 outage, where one byte-identical config aborted the entire deploy.)
 
 Operators can bypass the post-deploy invariant for diagnostic deploys via `BOSUN_SKIP_DEPLOY_INVARIANT=true`. The skip is logged at `Warn` level with `override=true` so it shows up in monitoring; the declared-state invariant is not affected by this flag.
 


### PR DESCRIPTION
Fixes #330.

## Problem

The deploy-sync invariant (`verifyDeployTarget`) fired `ErrDeployInvariantEmptyWrite` whenever a target recorded **zero writes** against a non-empty source — inferring failure from the write count alone, never inspecting the destination.

But content-hash sync (`CopyDirIfChanged`) legitimately writes 0 files when the destination already byte-matches the source. Through the live deploy path, **zero writes against a non-empty source can only mean "destination already matches"** (it writes whenever content differs or a file is missing) — so this branch was a false positive 100% of the time.

A single byte-identical config (`dnscrypt-proxy.toml`) aborted the entire reconcile **before `docker compose up`**, taking down 62 containers (`0/1 targets succeeded`). Latent bug, newly reachable after #319 first let the pipeline reach the file-deploy stage.

## Fix

The empty-writes branch now **inspects the destination** instead of guessing:

- Zero writes + every source file present at destination → legitimate no-op, **pass**.
- Zero writes + any source file missing → genuine silent-sync failure, **still fires** `ErrDeployInvariantEmptyWrite` (now with a `missing=…` field naming the first absent file).

New helper `firstMissingSourceFile` handles both directory and single-file targets, mirroring how the deploy maps source files onto the destination. This re-expresses the invariant as its true post-condition (files on disk) rather than the `WrittenFiles` proxy — correct and strictly stronger. The #214 genuine-failure cases (missing dst, stale mtime) still fail.

## Tests

- Flipped the test that encoded the bug: `TestDeployLocal_SilentEmptyWrite_FailsInvariant` → `TestDeployLocal_NoOpSync_PassesInvariant` (identical-content fixture must now pass).
- Added unit coverage: no-op pass (dir, nested, single-file) + partial-missing-destination still errors.
- Existing genuine-failure tests unchanged (empty destination → still errors).

## Docs

- ADR-0013 amendment recording the empty-write gate refinement.
- `skills/onboard/resources/gitops.md` and `docs/troubleshooting.md` corrected to describe destination-inspection behavior.

## Follow-up

Secondary observation in #330 (pre-deploy backup still times out at the full 5m every reconcile) tracked separately — not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)