### PR TITLE
fix(reconcile): harden deploy invariant with content-equality + symlink semantics

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,7 +55,7 @@ The render step produced no parseable services in `<staging>/compose/`. Either t
 
 **Invariant 2 — `deploy invariant: source has files but no writes recorded` / `destination file has stale mtime`**
 
-The deploy sync step claimed success but the destination doesn't reflect it. Two shapes trip this: (1) a written file's mtime is older than the reconcile start, or (2) zero files were written against a non-empty source **and a source file is missing from the destination**. Both are the GH#214 silent-sync signature — the write path silently failed. Note: a zero-write target whose destination already content-matches the source is a legitimate no-op and does **not** fail (fixed in GH#330); the error fires only when a file is genuinely absent. The `missing=…` field in the error names the first absent file.
+The deploy sync step claimed success but the destination doesn't reflect it. Two shapes trip this: (1) a written file's mtime is older than the reconcile start, or (2) zero files were written against a non-empty source **and a source file is missing from — or holds stale bytes at — the destination**. Both are the GH#214 silent-sync signature — the write path silently failed. The zero-write check is content-equality (SHA-256), not existence: a destination that already byte-matches the source is a legitimate no-op and does **not** fail (fixed in GH#330), but a file that exists at the right path with outdated content **does** fail (a stale write the sync silently failed to replace). The `mismatch=…` field in the error names the first absent-or-differing destination path. Symlinks in the source are skipped — they are never deployed, so they impose no requirement.
 
 To debug:
 

--- a/internal/reconcile/deploy.go
+++ b/internal/reconcile/deploy.go
@@ -427,5 +427,14 @@ func (d *DeployOps) DeployLocalFile(ctx context.Context, sourceFile, targetFile 
 		return nil
 	}
 
-	return fileutil.CopyFile(sourceFile, targetFile)
+	// Standard mode. A symlink source is intentionally not deployed — CopyDir
+	// and CopyFileIfChanged both Lstat-skip symlinks, so the single-file path
+	// must too. Treat ErrSymlinkSkipped as a benign no-op, not a deploy failure.
+	if err := fileutil.CopyFile(sourceFile, targetFile); err != nil {
+		if errors.Is(err, fileutil.ErrSymlinkSkipped) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/internal/reconcile/deploy_test.go
+++ b/internal/reconcile/deploy_test.go
@@ -1353,6 +1353,31 @@ func TestDeployOps_DeployLocalFile_StandardMode(t *testing.T) {
 	assert.Equal(t, "data", string(data))
 }
 
+// TestDeployOps_DeployLocalFile_StandardMode_SymlinkSwallowed covers the B2 fix:
+// in standard (non-content-hash) mode a symlink source must be treated as a
+// benign no-op — CopyFile returns ErrSymlinkSkipped, which DeployLocalFile
+// swallows rather than aborting the deploy. Content-hash mode already did this
+// via CopyFileIfChanged; this asserts parity for the standard path.
+func TestDeployOps_DeployLocalFile_StandardMode_SymlinkSwallowed(t *testing.T) {
+	tmpDir := t.TempDir()
+	realFile := filepath.Join(tmpDir, "real.yml")
+	srcLink := filepath.Join(tmpDir, "link.yml")
+	tgtFile := filepath.Join(tmpDir, "out", "target.yml")
+
+	require.NoError(t, os.WriteFile(realFile, []byte("data"), 0644))
+	require.NoError(t, os.Symlink(realFile, srcLink))
+
+	d := NewDeployOps(false, "")
+	d.ContentHashSync = false
+
+	err := d.DeployLocalFile(context.Background(), srcLink, tgtFile, nil)
+	require.NoError(t, err, "a symlink source must be a no-op, not a deploy failure")
+
+	// The symlink was skipped, so no target file should have been created.
+	_, statErr := os.Stat(tgtFile)
+	assert.True(t, os.IsNotExist(statErr), "skipped symlink must not produce a destination file")
+}
+
 // writeBackupArchive creates backupDir/configs.tar.gz containing the given
 // absolute file paths, mirroring how Backup() stores them (tar strips the
 // leading '/', so member "/x/y" is stored as "x/y"). Used to exercise the

--- a/internal/reconcile/verify.go
+++ b/internal/reconcile/verify.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/cameronsjo/bosun/internal/fileutil"
 	"github.com/cameronsjo/bosun/internal/log"
 )
 
@@ -19,9 +20,19 @@ var (
 )
 
 // verifyDeployTarget asserts every entry in writtenRel exists at dst with
-// mtime >= startTime, and that an empty writtenRel against a non-empty src is
-// an error. writtenRel paths are joined under dst — for directory targets dst
-// is the destination directory; for file targets dst is its parent dir.
+// mtime >= startTime. writtenRel paths are joined under dst — for directory
+// targets dst is the destination directory; for file targets dst is its parent
+// dir.
+//
+// When writtenRel is empty the deploy recorded zero writes, which is NOT
+// inherently a failure: content-hash sync writes nothing when the destination
+// already byte-matches the source (a no-op), and the standard rename-aside path
+// leaves dst content-identical to src without populating writtenRel. So rather
+// than inferring corruption from the write counter, verify on-disk truth — every
+// regular file in src must be present and content-equal at dst.
+// ErrDeployInvariantEmptyWrite fires only for a genuine silent-sync failure (a
+// non-empty source whose files are missing or differ at dst), the failure GH#214
+// added this guard for; a satisfied no-op passes (GH#330).
 func verifyDeployTarget(src, dst string, writtenRel []string, startTime time.Time) error {
 	logger := log.Component(log.ComponentReconcile)
 	logger.Debug().
@@ -31,33 +42,25 @@ func verifyDeployTarget(src, dst string, writtenRel []string, startTime time.Tim
 		Msg("Preparing to verify deploy target invariant")
 
 	if len(writtenRel) == 0 {
-		hasFiles, err := dirHasRegularFiles(src)
+		sawFiles, mismatch, err := destinationSatisfiesSource(src, dst)
 		if err != nil {
-			logger.Error().Err(err).Str(log.FieldPath, src).Msg("Failed to verify deploy target. Reason: cannot inspect source")
-			return fmt.Errorf("inspect source %q: %w", src, err)
+			logger.Error().Err(err).
+				Str(log.FieldPath, src).
+				Str("destination", dst).
+				Msg("Failed to verify deploy target. Reason: cannot compare source against destination")
+			return fmt.Errorf("compare source %q against destination %q: %w", src, dst, err)
 		}
-		if !hasFiles {
-			logger.Debug().Msg("Deploy target verification passed: empty source and no files written")
+		if !sawFiles {
+			logger.Debug().Msg("Deploy target verification passed: source has no regular files to deploy")
 			return nil
 		}
-		// Source has files but the sync recorded zero writes. With content-hash
-		// sync this is the legitimate no-op case: the destination already
-		// byte-matches the source, so CopyDirIfChanged correctly skipped every
-		// file (GH#330). Distinguish that from a genuine silent-sync failure by
-		// inspecting the destination — existence only, no mtime check, since the
-		// files were written on a prior run. Fail only when files are missing.
-		missing, err := firstMissingSourceFile(src, dst)
-		if err != nil {
-			logger.Error().Err(err).Str(log.FieldPath, dst).Msg("Failed to verify deploy target. Reason: cannot inspect destination")
-			return fmt.Errorf("inspect destination %q: %w", dst, err)
-		}
-		if missing != "" {
+		if mismatch != "" {
 			logger.Error().
 				Str(log.FieldPath, src).
 				Str("destination", dst).
-				Str("missing", missing).
-				Msg("Failed to verify deploy target. Reason: source file missing from destination after zero-write sync")
-			return fmt.Errorf("%w: src=%q dst=%q missing=%q", ErrDeployInvariantEmptyWrite, src, dst, missing)
+				Str("mismatch", mismatch).
+				Msg("Failed to verify deploy target. Reason: zero writes recorded and destination does not content-match source (silent-sync failure)")
+			return fmt.Errorf("%w: src=%q dst=%q mismatch=%q", ErrDeployInvariantEmptyWrite, src, dst, mismatch)
 		}
 		logger.Debug().
 			Str("destination", dst).
@@ -98,65 +101,97 @@ func verifyDeployTarget(src, dst string, writtenRel []string, startTime time.Tim
 	return nil
 }
 
-// firstMissingSourceFile reports the first regular file under src that has no
-// counterpart at dst, or "" if every source file is present. It mirrors how
-// the deploy maps source files onto the destination: a directory source maps
-// each file to its same relative path under dst; a single-file source maps to
-// dst/<basename>. Only existence is checked — callers use this for the no-op
-// (zero-write) sync case, where matching files were written on a prior run and
-// therefore carry old mtimes. A missing source is treated as "nothing missing".
-func firstMissingSourceFile(src, dst string) (string, error) {
-	info, err := os.Stat(src)
+// destinationSatisfiesSource reports whether a zero-write deploy left the
+// destination already mirroring the source — the on-disk truth check behind the
+// empty-write invariant. Instead of treating "source has files but no writes
+// recorded" as corruption, it confirms each regular file in src is present and
+// content-equal at dst.
+//
+// Symlinks are skipped (Lstat semantics) to match CopyDir/CopyDirIfChanged,
+// which never deploy them, so a symlink-only source imposes no requirement.
+// Content equality reuses fileutil.FileHash/ContentEqual — the same primitives
+// CopyFileIfChanged uses to decide a write is skippable — so "skipped because
+// equal" and "verified present" share one definition of equal.
+//
+// Returns (sawFiles, mismatch, err): sawFiles is whether src held at least one
+// regular file; mismatch is the first dst path that is missing or content-
+// differing ("" when every file is satisfied). It mirrors how the deploy maps
+// source onto destination: a directory source maps each file to its same
+// relative path under dst; a single-file source maps to dst/<basename>. A
+// missing source yields (false, "", nil).
+func destinationSatisfiesSource(src, dst string) (sawFiles bool, mismatch string, err error) {
+	info, err := os.Lstat(src)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return "", nil
+			return false, "", nil
 		}
-		return "", err
+		return false, "", err
 	}
 
 	if !info.IsDir() {
-		target := filepath.Join(dst, filepath.Base(src))
-		if _, err := os.Stat(target); err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				return target, nil
-			}
-			return "", err
+		// A symlink (or other non-regular entry) is never deployed, so it
+		// imposes no requirement on the destination.
+		if !info.Mode().IsRegular() {
+			return false, "", nil
 		}
-		return "", nil
+		target := filepath.Join(dst, filepath.Base(src))
+		equal, eqErr := fileEqual(src, target)
+		if eqErr != nil {
+			return true, "", eqErr
+		}
+		if !equal {
+			return true, target, nil
+		}
+		return true, "", nil
 	}
 
-	var missing string
-	walkErr := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
+	walkErr := filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
+		// IsRegular() is false for directories and symlinks alike, matching the
+		// copy path's symlink skip.
 		if !d.Type().IsRegular() {
 			return nil
 		}
+		sawFiles = true
 		rel, relErr := filepath.Rel(src, path)
 		if relErr != nil {
 			return relErr
 		}
 		target := filepath.Join(dst, rel)
-		if _, statErr := os.Stat(target); statErr != nil {
-			if errors.Is(statErr, fs.ErrNotExist) {
-				missing = target
-				return fs.SkipAll
-			}
-			return statErr
+		equal, eqErr := fileEqual(path, target)
+		if eqErr != nil {
+			return eqErr
+		}
+		if !equal {
+			mismatch = target
+			return fs.SkipAll
 		}
 		return nil
 	})
 	if walkErr != nil {
-		return "", walkErr
+		return sawFiles, "", walkErr
 	}
-	return missing, nil
+	return sawFiles, mismatch, nil
+}
+
+// fileEqual reports whether dst exists and is byte-identical to src, using the
+// same SHA-256 comparison CopyFileIfChanged relies on. A missing dst is
+// (false, nil) — i.e. a mismatch, not an error.
+func fileEqual(src, dst string) (bool, error) {
+	srcHash, err := fileutil.FileHash(src)
+	if err != nil {
+		return false, err
+	}
+	return fileutil.ContentEqual(dst, srcHash)
 }
 
 // dirHasRegularFiles reports whether src is, or recursively contains, at
-// least one regular file. Returns (false, nil) for a missing path.
+// least one regular file. Symlinks are not counted (Lstat semantics), matching
+// the copy path which never deploys them. Returns (false, nil) for a missing path.
 func dirHasRegularFiles(src string) (bool, error) {
-	info, err := os.Stat(src)
+	info, err := os.Lstat(src)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil

--- a/internal/reconcile/verify_test.go
+++ b/internal/reconcile/verify_test.go
@@ -98,6 +98,56 @@ func TestVerifyDeployTarget_ZeroWriteScenarios(t *testing.T) {
 			errContains: []string{"absent.yml"},
 		},
 		{
+			// Existence-only would PASS this (the file is present); content-
+			// equality catches the stale write the sync silently failed to replace.
+			name: "dir source, destination has stale content → silent failure errors",
+			setup: func(t *testing.T, dir string) (string, string) {
+				src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+				touchFile(t, filepath.Join(src, "config.toml"), "server = \"new\"\n", stale)
+				touchFile(t, filepath.Join(dst, "config.toml"), "server = \"old\"\n", stale)
+				return src, dst
+			},
+			wantErr:     true,
+			errContains: []string{"config.toml"},
+		},
+		{
+			name: "dir source, nested file has stale content → silent failure errors",
+			setup: func(t *testing.T, dir string) (string, string) {
+				src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+				touchFile(t, filepath.Join(src, "top.yml"), "a", stale)
+				touchFile(t, filepath.Join(src, "sub", "nested.yml"), "fresh", stale)
+				touchFile(t, filepath.Join(dst, "top.yml"), "a", stale)
+				touchFile(t, filepath.Join(dst, "sub", "nested.yml"), "stale", stale)
+				return src, dst
+			},
+			wantErr:     true,
+			errContains: []string{"nested.yml"},
+		},
+		{
+			name: "file source, destination has stale content → silent failure errors",
+			setup: func(t *testing.T, dir string) (string, string) {
+				srcFile := filepath.Join(dir, "src", "single.yml")
+				dstDir := filepath.Join(dir, "dst")
+				touchFile(t, srcFile, "v2", stale)
+				touchFile(t, filepath.Join(dstDir, "single.yml"), "v1", stale)
+				return srcFile, dstDir
+			},
+			wantErr:     true,
+			errContains: []string{"single.yml"},
+		},
+		{
+			// Symlink-only source: the copy path never deploys symlinks, so the
+			// invariant must impose no requirement and pass.
+			name: "dir source with only a symlink → passes (symlink not deployed)",
+			setup: func(t *testing.T, dir string) (string, string) {
+				src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+				require.NoError(t, os.MkdirAll(src, 0755))
+				require.NoError(t, os.MkdirAll(dst, 0755))
+				require.NoError(t, os.Symlink("/nonexistent/target", filepath.Join(src, "link.yml")))
+				return src, dst
+			},
+		},
+		{
 			name: "file source, destination matches → no-op passes",
 			setup: func(t *testing.T, dir string) (string, string) {
 				srcFile := filepath.Join(dir, "src", "single.yml")
@@ -265,56 +315,119 @@ func TestVerifyDeployTarget_SrcIsRegularFile_HealthyPasses(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestFirstMissingSourceFile exercises the helper directly, including branches
-// verifyDeployTarget cannot reach (a missing source short-circuits earlier via
-// dirHasRegularFiles) and the stat-error path.
-func TestFirstMissingSourceFile(t *testing.T) {
-	t.Run("missing source returns nothing missing", func(t *testing.T) {
+// TestDestinationSatisfiesSource exercises the helper directly, including
+// branches verifyDeployTarget reaches only obliquely: the missing-source
+// short-circuit, content-equality (present-but-differing), symlink skipping
+// (Lstat semantics), and the walk stat-error path. The helper returns
+// (sawFiles, mismatch, err): sawFiles is whether the source held any regular
+// file; mismatch is the first absent-or-differing destination path ("" when
+// satisfied).
+func TestDestinationSatisfiesSource(t *testing.T) {
+	t.Run("missing source: no files, no mismatch", func(t *testing.T) {
 		dir := t.TempDir()
-		missing, err := firstMissingSourceFile(filepath.Join(dir, "nope"), dir)
+		sawFiles, mismatch, err := destinationSatisfiesSource(filepath.Join(dir, "nope"), dir)
 		require.NoError(t, err)
-		assert.Empty(t, missing)
+		assert.False(t, sawFiles)
+		assert.Empty(t, mismatch)
 	})
 
-	t.Run("dir source all present returns empty", func(t *testing.T) {
+	t.Run("dir source all present and content-equal: satisfied", func(t *testing.T) {
 		dir := t.TempDir()
 		src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
 		touchFile(t, filepath.Join(src, "a.yml"), "a", time.Now())
+		touchFile(t, filepath.Join(src, "sub", "b.yml"), "b", time.Now())
 		touchFile(t, filepath.Join(dst, "a.yml"), "a", time.Now())
-		missing, err := firstMissingSourceFile(src, dst)
+		touchFile(t, filepath.Join(dst, "sub", "b.yml"), "b", time.Now())
+		sawFiles, mismatch, err := destinationSatisfiesSource(src, dst)
 		require.NoError(t, err)
-		assert.Empty(t, missing)
+		assert.True(t, sawFiles)
+		assert.Empty(t, mismatch)
 	})
 
-	t.Run("dir source missing file returns its destination path", func(t *testing.T) {
+	t.Run("dir source missing file: mismatch names destination path", func(t *testing.T) {
 		dir := t.TempDir()
 		src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
 		touchFile(t, filepath.Join(src, "a.yml"), "a", time.Now())
 		require.NoError(t, os.MkdirAll(dst, 0755))
-		missing, err := firstMissingSourceFile(src, dst)
+		sawFiles, mismatch, err := destinationSatisfiesSource(src, dst)
 		require.NoError(t, err)
-		assert.Equal(t, filepath.Join(dst, "a.yml"), missing)
+		assert.True(t, sawFiles)
+		assert.Equal(t, filepath.Join(dst, "a.yml"), mismatch)
 	})
 
-	t.Run("file source present returns empty, absent returns path", func(t *testing.T) {
+	t.Run("dir source present but differing content: mismatch names destination path", func(t *testing.T) {
+		dir := t.TempDir()
+		src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+		touchFile(t, filepath.Join(src, "a.yml"), "fresh", time.Now())
+		touchFile(t, filepath.Join(dst, "a.yml"), "stale", time.Now())
+		sawFiles, mismatch, err := destinationSatisfiesSource(src, dst)
+		require.NoError(t, err)
+		assert.True(t, sawFiles)
+		assert.Equal(t, filepath.Join(dst, "a.yml"), mismatch)
+	})
+
+	t.Run("file source: equal satisfied, differing and absent mismatch", func(t *testing.T) {
 		dir := t.TempDir()
 		srcFile := filepath.Join(dir, "single.yml")
 		touchFile(t, srcFile, "v", time.Now())
-		dstWith := filepath.Join(dir, "with")
-		touchFile(t, filepath.Join(dstWith, "single.yml"), "v", time.Now())
 
-		missing, err := firstMissingSourceFile(srcFile, dstWith)
+		dstEqual := filepath.Join(dir, "equal")
+		touchFile(t, filepath.Join(dstEqual, "single.yml"), "v", time.Now())
+		sawFiles, mismatch, err := destinationSatisfiesSource(srcFile, dstEqual)
 		require.NoError(t, err)
-		assert.Empty(t, missing)
+		assert.True(t, sawFiles)
+		assert.Empty(t, mismatch)
 
-		dstWithout := filepath.Join(dir, "without")
-		require.NoError(t, os.MkdirAll(dstWithout, 0755))
-		missing, err = firstMissingSourceFile(srcFile, dstWithout)
+		dstDiffer := filepath.Join(dir, "differ")
+		touchFile(t, filepath.Join(dstDiffer, "single.yml"), "other", time.Now())
+		sawFiles, mismatch, err = destinationSatisfiesSource(srcFile, dstDiffer)
 		require.NoError(t, err)
-		assert.Equal(t, filepath.Join(dstWithout, "single.yml"), missing)
+		assert.True(t, sawFiles)
+		assert.Equal(t, filepath.Join(dstDiffer, "single.yml"), mismatch)
+
+		dstAbsent := filepath.Join(dir, "absent")
+		require.NoError(t, os.MkdirAll(dstAbsent, 0755))
+		sawFiles, mismatch, err = destinationSatisfiesSource(srcFile, dstAbsent)
+		require.NoError(t, err)
+		assert.True(t, sawFiles)
+		assert.Equal(t, filepath.Join(dstAbsent, "single.yml"), mismatch)
 	})
 
-	t.Run("unreadable source subtree surfaces stat error", func(t *testing.T) {
+	t.Run("symlink source file: no requirement (not deployed)", func(t *testing.T) {
+		dir := t.TempDir()
+		srcLink := filepath.Join(dir, "link.yml")
+		require.NoError(t, os.Symlink("/nonexistent/target", srcLink))
+		sawFiles, mismatch, err := destinationSatisfiesSource(srcLink, filepath.Join(dir, "dst"))
+		require.NoError(t, err)
+		assert.False(t, sawFiles, "a symlink is not a regular file, so it imposes no requirement")
+		assert.Empty(t, mismatch)
+	})
+
+	t.Run("dir source: symlinks skipped, regular files still checked", func(t *testing.T) {
+		dir := t.TempDir()
+		src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+		touchFile(t, filepath.Join(src, "real.yml"), "x", time.Now())
+		require.NoError(t, os.Symlink("/nonexistent/target", filepath.Join(src, "link.yml")))
+		touchFile(t, filepath.Join(dst, "real.yml"), "x", time.Now())
+		// dst has no link.yml — but the source symlink is skipped, so this is satisfied.
+		sawFiles, mismatch, err := destinationSatisfiesSource(src, dst)
+		require.NoError(t, err)
+		assert.True(t, sawFiles)
+		assert.Empty(t, mismatch, "the source symlink must not be required at the destination")
+	})
+
+	t.Run("dir source with only symlinks: no regular files seen", func(t *testing.T) {
+		dir := t.TempDir()
+		src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+		require.NoError(t, os.MkdirAll(src, 0755))
+		require.NoError(t, os.Symlink("/nonexistent/target", filepath.Join(src, "link.yml")))
+		sawFiles, mismatch, err := destinationSatisfiesSource(src, dst)
+		require.NoError(t, err)
+		assert.False(t, sawFiles)
+		assert.Empty(t, mismatch)
+	})
+
+	t.Run("unreadable source subtree surfaces walk error", func(t *testing.T) {
 		if os.Geteuid() == 0 {
 			t.Skip("running as root bypasses directory permissions")
 		}
@@ -325,7 +438,7 @@ func TestFirstMissingSourceFile(t *testing.T) {
 		require.NoError(t, os.Chmod(filepath.Join(src, "sub"), 0000))
 		t.Cleanup(func() { _ = os.Chmod(filepath.Join(src, "sub"), 0755) })
 
-		_, err := firstMissingSourceFile(src, filepath.Join(dir, "dst"))
+		_, _, err := destinationSatisfiesSource(src, filepath.Join(dir, "dst"))
 		require.Error(t, err)
 	})
 }
@@ -474,6 +587,43 @@ func TestDeployLocal_NoOpSync_PassesInvariant(t *testing.T) {
 	result, err := r.deployLocal(context.Background(), nil)
 	require.NoError(t, err, "a no-op sync against a content-matched destination must not trip the invariant")
 	assert.NotNil(t, result)
+}
+
+// TestDeployLocal_StandardMode_PassesInvariant is the B1 shape: standard
+// (non-content-hash) deploy nuke-and-replaces the target and records ZERO
+// writes (DeployLocal never calls AddWritten in this mode). The invariant must
+// not infer a silent-sync failure from the empty write list — it inspects the
+// destination directly and passes because the freshly copied files are
+// content-equal to the source. This locks in that the content-equality invariant
+// covers both deploy strategies, not just content-hash sync.
+func TestDeployLocal_StandardMode_PassesInvariant(t *testing.T) {
+	fx := newDeployLocalFixture(t)
+	now := time.Now()
+	// Differing dst content forces standard mode to actually overwrite; it still
+	// records no writes, so the invariant relies on post-deploy content equality.
+	touchFile(t, filepath.Join(fx.freshrssStaging, "config.yml"), "new-content", now)
+	touchFile(t, filepath.Join(fx.freshrssAppdata, "config.yml"), "old-content", now.Add(-24*time.Hour))
+	touchFile(t, filepath.Join(fx.composeStaging, "stub.yml"), "services:\n  stub: {}\n", now)
+	require.NoError(t, os.MkdirAll(fx.composeAppdata, 0755))
+
+	cfg := &Config{
+		StagingDir:       fx.stagingDir,
+		InfraSubDir:      "unraid",
+		LocalAppdataPath: fx.appdataDir,
+	}
+	// Standard mode: ContentHashSync disabled.
+	standard := &DeployOps{DryRun: false, ProjectName: "test", ContentHashSync: false, composeUpFn: noopComposeUp}
+	r := NewReconciler(cfg, WithDeployOps(standard))
+
+	result, err := r.deployLocal(context.Background(), nil)
+	require.NoError(t, err, "standard-mode deploy records zero writes but leaves dst content-equal; invariant must pass")
+	require.NotNil(t, result)
+	assert.Empty(t, result.WrittenFiles, "standard mode does not populate WrittenFiles")
+
+	// Confirm the deploy actually landed the new content (not just that the gate passed).
+	got, err := os.ReadFile(filepath.Join(fx.freshrssAppdata, "config.yml"))
+	require.NoError(t, err)
+	assert.Equal(t, "new-content", string(got))
 }
 
 func TestDeployLocal_SkipDeployInvariant_BypassesCheck(t *testing.T) {

--- a/internal/reconcile/verify_test.go
+++ b/internal/reconcile/verify_test.go
@@ -441,6 +441,71 @@ func TestDestinationSatisfiesSource(t *testing.T) {
 		_, _, err := destinationSatisfiesSource(src, filepath.Join(dir, "dst"))
 		require.Error(t, err)
 	})
+
+	t.Run("lstat error (non-directory parent) surfaces, not treated as missing", func(t *testing.T) {
+		dir := t.TempDir()
+		// A regular file used as a path's parent component yields ENOTDIR from
+		// Lstat — a real I/O error, distinct from fs.ErrNotExist (which would
+		// short-circuit to "no files, no mismatch").
+		notADir := filepath.Join(dir, "notadir")
+		touchFile(t, notADir, "x", time.Now())
+		sawFiles, mismatch, err := destinationSatisfiesSource(filepath.Join(notADir, "child"), filepath.Join(dir, "dst"))
+		require.Error(t, err)
+		assert.False(t, sawFiles)
+		assert.Empty(t, mismatch)
+	})
+
+	t.Run("unreadable regular file in dir source surfaces hash error", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("running as root bypasses file permissions")
+		}
+		dir := t.TempDir()
+		src, dst := filepath.Join(dir, "src"), filepath.Join(dir, "dst")
+		touchFile(t, filepath.Join(src, "a.yml"), "a", time.Now())
+		require.NoError(t, os.Chmod(filepath.Join(src, "a.yml"), 0000))
+		t.Cleanup(func() { _ = os.Chmod(filepath.Join(src, "a.yml"), 0644) })
+
+		// Walk reaches the regular file, then FileHash(src) fails to open it.
+		_, _, err := destinationSatisfiesSource(src, dst)
+		require.Error(t, err)
+	})
+
+	t.Run("unreadable single-file source surfaces hash error", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("running as root bypasses file permissions")
+		}
+		dir := t.TempDir()
+		srcFile := filepath.Join(dir, "single.yml")
+		touchFile(t, srcFile, "v", time.Now())
+		require.NoError(t, os.Chmod(srcFile, 0000))
+		t.Cleanup(func() { _ = os.Chmod(srcFile, 0644) })
+
+		sawFiles, _, err := destinationSatisfiesSource(srcFile, filepath.Join(dir, "dst"))
+		require.Error(t, err)
+		assert.True(t, sawFiles, "a regular (if unreadable) file still counts as seen")
+	})
+}
+
+// TestVerifyDeployTarget_CompareError_Surfaces covers the empty-writes branch's
+// error path: when destinationSatisfiesSource cannot compare (an I/O failure
+// hashing the source), verifyDeployTarget wraps it as a "compare source" error
+// — distinct from the silent-sync sentinel, since the gate could not reach a
+// verdict.
+func TestVerifyDeployTarget_CompareError_Surfaces(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses file permissions")
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	touchFile(t, filepath.Join(src, "a.yml"), "a", time.Now())
+	require.NoError(t, os.Chmod(filepath.Join(src, "a.yml"), 0000))
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(src, "a.yml"), 0644) })
+
+	err := verifyDeployTarget(src, dst, nil, time.Now().Add(-time.Minute))
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrDeployInvariantEmptyWrite, "an I/O comparison failure is not a silent-sync verdict")
+	assert.Contains(t, err.Error(), "compare source")
 }
 
 func TestDirHasRegularFiles(t *testing.T) {

--- a/openspec/changes/add-deploy-sync-invariants/specs/reconcile/spec.md
+++ b/openspec/changes/add-deploy-sync-invariants/specs/reconcile/spec.md
@@ -15,7 +15,16 @@ The reconciler SHALL enforce three invariants between deploy sync (stage 8) and 
 
 **Invariant 2 — Written files exist with fresh mtime.** After deploy sync completes, for each path in `WrittenFiles` across all targets, the reconciler SHALL stat the destination path and assert `mtime >= reconcileStartTime`. If any destination is missing or stale, the reconciler SHALL fail before compose-up runs.
 
-**Invariant 3 — Non-empty source must be reflected at the destination.** For each deploy target whose source staging directory contains at least one regular file but whose `WrittenFiles` slice is empty, the reconciler SHALL inspect the destination directly: it SHALL assert that every regular file in the source is present at its corresponding destination path AND byte-identical to the source (SHA-256 content equality — the same comparison `CopyFileIfChanged` uses to decide a write is skippable; no mtime assertion, since a content-hash match means the files were written on a prior run). Symlinks in the source SHALL be skipped (Lstat semantics), matching the copy path, which never deploys them; a symlink-only source therefore imposes no requirement on the destination. If every source file is present and content-equal, the zero-write result is a legitimate no-op (the destination already byte-matches the source) and the invariant SHALL pass. If any source file is absent from the destination or differs in content, the sync silently failed and the reconciler SHALL fail the run, naming the first mismatching destination path.
+**Invariant 3 — Non-empty source must be reflected at the destination.** For each deploy target whose source staging directory contains at least one regular file but whose `WrittenFiles` slice is empty, the reconciler SHALL:
+
+- Inspect the destination directly rather than inferring corruption from the empty write list.
+- Assert that every regular file in the source is present at its corresponding destination path.
+- Assert that every such file is byte-identical to the source using SHA-256 content equality — the same comparison `CopyFileIfChanged` uses to decide a write is skippable. No mtime assertion is performed, since a content-hash match means the files were written on a prior run.
+- Skip symlinks in the source using Lstat semantics, matching the copy path, which never deploys them.
+- Pass the invariant when every source file is present and content-equal — a legitimate no-op, since the destination already byte-matches the source.
+- Fail the run when any source file is absent from the destination or differs in content, naming the first mismatching destination path.
+
+A symlink-only source therefore imposes no requirement on the destination.
 
 This refines the original formulation, which failed *any* zero-write target against a non-empty source. That was too aggressive: with content-hash sync a target legitimately records zero writes when the destination already matches, so a single byte-identical config could abort an entire reconcile (see GH#330). Asserting the real post-condition — files present *and content-equal* at the destination — preserves protection against silent-sync failures while permitting genuine no-ops. Existence alone is insufficient: a stale destination file occupying the right path would pass an existence check yet serve outdated config, so content equality closes that gap.
 

--- a/openspec/changes/add-deploy-sync-invariants/specs/reconcile/spec.md
+++ b/openspec/changes/add-deploy-sync-invariants/specs/reconcile/spec.md
@@ -15,9 +15,9 @@ The reconciler SHALL enforce three invariants between deploy sync (stage 8) and 
 
 **Invariant 2 — Written files exist with fresh mtime.** After deploy sync completes, for each path in `WrittenFiles` across all targets, the reconciler SHALL stat the destination path and assert `mtime >= reconcileStartTime`. If any destination is missing or stale, the reconciler SHALL fail before compose-up runs.
 
-**Invariant 3 — Non-empty source must be reflected at the destination.** For each deploy target whose source staging directory contains at least one regular file but whose `WrittenFiles` slice is empty, the reconciler SHALL inspect the destination directly: it SHALL assert that every regular file in the source exists at its corresponding destination path (existence only — no mtime assertion, since a content-hash match means the files were written on a prior run). If every source file is present, the zero-write result is a legitimate no-op (the destination already byte-matches the source) and the invariant SHALL pass. If any source file is absent from the destination, the sync silently failed and the reconciler SHALL fail the run, naming the first missing file.
+**Invariant 3 — Non-empty source must be reflected at the destination.** For each deploy target whose source staging directory contains at least one regular file but whose `WrittenFiles` slice is empty, the reconciler SHALL inspect the destination directly: it SHALL assert that every regular file in the source is present at its corresponding destination path AND byte-identical to the source (SHA-256 content equality — the same comparison `CopyFileIfChanged` uses to decide a write is skippable; no mtime assertion, since a content-hash match means the files were written on a prior run). Symlinks in the source SHALL be skipped (Lstat semantics), matching the copy path, which never deploys them; a symlink-only source therefore imposes no requirement on the destination. If every source file is present and content-equal, the zero-write result is a legitimate no-op (the destination already byte-matches the source) and the invariant SHALL pass. If any source file is absent from the destination or differs in content, the sync silently failed and the reconciler SHALL fail the run, naming the first mismatching destination path.
 
-This refines the original formulation, which failed *any* zero-write target against a non-empty source. That was too aggressive: with content-hash sync a target legitimately records zero writes when the destination already matches, so a single byte-identical config could abort an entire reconcile (see GH#330). Asserting the real post-condition — files present at the destination — preserves protection against silent-sync failures while permitting genuine no-ops.
+This refines the original formulation, which failed *any* zero-write target against a non-empty source. That was too aggressive: with content-hash sync a target legitimately records zero writes when the destination already matches, so a single byte-identical config could abort an entire reconcile (see GH#330). Asserting the real post-condition — files present *and content-equal* at the destination — preserves protection against silent-sync failures while permitting genuine no-ops. Existence alone is insufficient: a stale destination file occupying the right path would pass an existence check yet serve outdated config, so content equality closes that gap.
 
 The invariant check (invariants 2 and 3) MAY be skipped via `BOSUN_SKIP_DEPLOY_INVARIANT=true` for diagnostic or development scenarios. When skipped, the reconciler SHALL log at `Warn` level noting that invariants are disabled.
 
@@ -57,7 +57,7 @@ Per-file write decisions SHALL be observable: `CopyDirIfChanged` and `CopyFileIf
 
 - **WHEN** a deploy target's source staging directory contains regular files
 - **AND** the target's `WrittenFiles` returned by `CopyDirIfChanged` is empty
-- **AND** every source file already exists at its corresponding destination path
+- **AND** every source file already exists at its corresponding destination path and is byte-identical to the source
 - **THEN** the invariant check passes at stage 9 (legitimate no-op — destination already byte-matches)
 - **AND** compose up proceeds normally
 
@@ -68,7 +68,23 @@ Per-file write decisions SHALL be observable: `CopyDirIfChanged` and `CopyFileIf
 - **AND** at least one source file is absent from the destination
 - **THEN** the invariant check fails at stage 9
 - **AND** compose up does not run
-- **AND** the error message names the first source file missing from the destination
+- **AND** the error message names the first mismatching destination path
+
+#### Scenario: Empty WrittenFiles with a stale-content destination file blocks compose-up
+
+- **WHEN** a deploy target's source staging directory contains regular files
+- **AND** the target's `WrittenFiles` returned by `CopyDirIfChanged` is empty
+- **AND** a destination file exists at the corresponding path but its content differs from the source (a stale write the content-hash sync failed to replace)
+- **THEN** the invariant check fails at stage 9
+- **AND** compose up does not run
+- **AND** the error message names the first mismatching destination path
+
+#### Scenario: Symlinks in the source impose no destination requirement
+
+- **WHEN** a deploy target's source staging directory contains only symlinks (no regular files)
+- **AND** the target's `WrittenFiles` is empty
+- **THEN** the invariant check passes at stage 9 (symlinks are never deployed, so nothing is required at the destination)
+- **AND** compose up proceeds normally
 
 #### Scenario: Healthy deploy passes invariant check
 

--- a/openspec/changes/add-deploy-sync-invariants/tasks.md
+++ b/openspec/changes/add-deploy-sync-invariants/tasks.md
@@ -28,13 +28,16 @@ Implementation runs in three layers. Layer 1 ships the invariants and observabil
 
 - [x] `internal/reconcile/verify.go` (new file) — `verifyDeployTarget(src, dst, writtenRel, startTime) error` helper
 - [x] `internal/reconcile/verify.go` — invariant: each `WrittenFiles` entry must exist at destination with `mtime >= startTime`
-- [x] `internal/reconcile/verify.go` — invariant: empty `WrittenFiles` against non-empty source inspects the destination — passes on a content-matched no-op, errors (naming the missing file) when a source file is absent (refined per GH#330; `firstMissingSourceFile` helper)
+- [x] `internal/reconcile/verify.go` — invariant: empty `WrittenFiles` against non-empty source inspects the destination — passes on a content-matched no-op, errors (naming the first mismatching path) when a source file is absent OR byte-differs at the destination; symlinks skipped (Lstat). Refined per GH#330 (existence) then GH#330 follow-up (content-equality); `destinationSatisfiesSource` + `fileEqual` helpers reusing `fileutil.FileHash`/`ContentEqual`
+- [x] `internal/reconcile/verify.go` — `dirHasRegularFiles` uses `os.Lstat` so a symlink-only source counts no regular files (matches the copy path, which never deploys symlinks)
+- [x] `internal/reconcile/deploy.go` — `DeployLocalFile` standard mode swallows the benign `fileutil.ErrSymlinkSkipped` instead of failing the deploy (B2; parity with content-hash mode and `CopyDir`)
 - [x] `internal/reconcile/reconcile.go` — call `verifyDeployTarget` per-target inside `deployLocal` before `PrefixLatest`
 - [x] `internal/daemon/daemon.go` — parse `BOSUN_SKIP_DEPLOY_INVARIANT` in `ConfigFromEnv()` (landed in Layer 1.2 commit alongside `BOSUN_ALLOW_EMPTY_DECLARED_STATE`)
 - [x] `internal/reconcile/verify_test.go` — `TestVerifyDeployTarget_StaleDestination_Errors`
-- [x] `internal/reconcile/verify_test.go` — `TestVerifyDeployTarget_ZeroWriteScenarios` (table-driven: no-op passes, missing-file errors; refined per GH#330)
+- [x] `internal/reconcile/verify_test.go` — `TestVerifyDeployTarget_ZeroWriteScenarios` (table-driven: no-op passes, missing-file errors, stale-content errors, symlink-only passes; refined per GH#330) + `TestDestinationSatisfiesSource` (helper-level: content-equality, symlink skip, stat-error)
 - [x] `internal/reconcile/verify_test.go` — `TestDeployLocal_SkipDeployInvariant_BypassesCheck` (env wiring through `deployLocal`)
-- [x] `internal/reconcile/verify_test.go` — `TestVerifyDeployTarget_HealthyDeploy_Passes` + `TestDeployLocal_HealthyDeploy_PassesInvariant`
+- [x] `internal/reconcile/verify_test.go` — `TestDeployLocal_StandardMode_PassesInvariant` (B1: zero recorded writes in standard mode still passes via content-equality) + `TestVerifyDeployTarget_HealthyDeploy_Passes` + `TestDeployLocal_HealthyDeploy_PassesInvariant`
+- [x] `internal/reconcile/deploy_test.go` — `TestDeployOps_DeployLocalFile_StandardMode_SymlinkSwallowed` (B2: symlink source is a no-op, not a deploy failure)
 
 ### 1.4 Regression guard
 

--- a/skills/onboard/resources/gitops.md
+++ b/skills/onboard/resources/gitops.md
@@ -35,8 +35,9 @@ Every reconciliation follows this 16-stage sequence:
         |
  9. Verify deploy-sync invariants — every WrittenFiles entry must exist
     with fresh mtime; empty WrittenFiles against a non-empty source fails
-    only when the destination is missing those files (a no-op sync that
-    already matches passes). Skipped if BOSUN_SKIP_DEPLOY_INVARIANT=true.
+    when any source file is missing OR byte-differs at the destination (a
+    no-op sync whose destination already content-matches passes; symlinks
+    are skipped). Skipped if BOSUN_SKIP_DEPLOY_INVARIANT=true.
         |
 10. Run docker compose up (per-file isolated, with rollback)
         |
@@ -60,7 +61,7 @@ Every reconciliation follows this 16-stage sequence:
 Bosun enforces two invariant gates that turn the GH#214 silent-success failure mode into a loud error:
 
 - **Declared-state invariant (stage 6)** — if `ExtractDeclaredState` returns `ErrComposeDirMissing` the reconcile fails unconditionally (no override). When the infra dir has no `compose/` but a sibling directory does, the error names the candidate and suggests the `BOSUN_INFRA_DIR` value to set (e.g. `did you mean BOSUN_INFRA_DIR=unraid?`) — the GH#214 misconfiguration. If it returns `ErrNoDeclaredServices` the reconcile fails unless `BOSUN_ALLOW_EMPTY_DECLARED_STATE=true` is set; the override logs at `Warn` level with `override=true`.
-- **Post-deploy invariant (stage 9)** — for every file in `DeployResult.WrittenFiles`, the destination must exist at `mtime >= reconcileStartTime`. When a deploy target records zero writes against a non-empty source, the gate inspects the destination directly: if every source file is already present it is a legitimate no-op sync (content-hash match) and passes; if any file is missing it is the GH#214 silent-sync failure and fails the reconcile before `docker compose up` runs. (The earlier behavior — treating *any* zero-write target as a failure — caused the GH#330 outage, where one byte-identical config aborted the entire deploy.)
+- **Post-deploy invariant (stage 9)** — for every file in `DeployResult.WrittenFiles`, the destination must exist at `mtime >= reconcileStartTime`. When a deploy target records zero writes against a non-empty source, the gate inspects the destination directly: every regular source file must be present **and byte-identical** at the destination (SHA-256, the same comparison `CopyFileIfChanged` uses to decide a write is skippable; symlinks are skipped to match the copy path). If every file is content-equal it is a legitimate no-op sync and passes; if any file is missing **or holds stale bytes** it is the GH#214 silent-sync failure and fails the reconcile before `docker compose up` runs, naming the first mismatching destination path. (The earlier behavior — treating *any* zero-write target as a failure — caused the GH#330 outage, where one byte-identical config aborted the entire deploy. A subsequent existence-only check fixed that but let a stale file occupying the right path pass; content-equality closes that gap.)
 
 Operators can bypass the post-deploy invariant for diagnostic deploys via `BOSUN_SKIP_DEPLOY_INVARIANT=true`. The skip is logged at `Warn` level with `override=true` so it shows up in monitoring; the declared-state invariant is not affected by this flag.
 


### PR DESCRIPTION
## Summary

Hardens the deploy-sync empty-write invariant (GH#330) from **existence-only** to **content-equality**, and fixes two symlink-handling gaps in the standard deploy path. Salvaged from the unmerged #362.

PR #368 fixed the GH#330 outage by replacing "zero writes against a non-empty source = corruption" with "every source file must *exist* at the destination." That permits legitimate no-ops, but a **stale destination file occupying the right path still passes** — serving outdated config, the exact silent-sync class the invariant exists to catch.

## What changed

- **`verify.go`** — replace existence-only `firstMissingSourceFile` with `destinationSatisfiesSource`, which confirms each regular source file is **byte-identical** at the destination (SHA-256 via `fileutil.FileHash`/`ContentEqual` — the same primitives `CopyFileIfChanged` uses to decide a write is skippable, so "skipped because equal" and "verified present" share one definition of equal). Symlinks are skipped (Lstat), matching the copy path which never deploys them. `dirHasRegularFiles` switched to `os.Lstat` for the same reason.
- **`deploy.go` (B2)** — `DeployLocalFile` standard mode now swallows the benign `fileutil.ErrSymlinkSkipped` sentinel instead of failing the deploy. Content-hash mode already did this via `CopyFileIfChanged`; this restores parity with `CopyDir`.

## Behavioral change

A zero-write deploy target whose destination file **exists but holds different bytes** now fails the invariant before `docker compose up` (previously passed). Genuine no-ops (destination already byte-matches) still pass.

## Tests

- `TestVerifyDeployTarget_ZeroWriteScenarios` — added stale-content (dir, nested, file-source) and symlink-only cases.
- `TestDestinationSatisfiesSource` — helper-level content-equality, symlink skip, stat-error.
- `TestDeployLocal_StandardMode_PassesInvariant` — **B1**: standard mode records zero writes yet passes via on-disk content-equality.
- `TestDeployOps_DeployLocalFile_StandardMode_SymlinkSwallowed` — **B2**: symlink source is a no-op, not a deploy failure.

`go test ./internal/reconcile/ ./internal/fileutil/` passes (only the Docker-gated `TestReconcilerRunFullSuccess` fails locally — no Docker daemon in this environment). OpenSpec `add-deploy-sync-invariants` revalidated `--strict`; Invariant 3 wording + scenarios updated (existence → content-equality).

Refs: bosun-lov, GH#330 (salvaged from #362)

🤖 Generated with [Claude Code](https://claude.com/claude-code)