### PR TITLE
fix(reconcile): scope pre-deploy backup to deployed config footprint

### DIFF
--- a/internal/reconcile/backup.go
+++ b/internal/reconcile/backup.go
@@ -160,12 +160,14 @@ func (d *DeployOps) Backup(ctx context.Context, backupDir string, paths []string
 		logger.Warn().Err(absErr).Str(log.FieldPath, backupDir).
 			Msg("Failed to resolve absolute backup path; self-exclusion skipped")
 	}
-	// Feed the path list to tar via stdin (-T -) rather than argv: the deployed
-	// footprint can be many files, which as an argument list would risk ARG_MAX.
-	// Both GNU tar and bsdtar read newline-separated names from "-".
-	args = append(args, "-T", "-")
+	// Feed the path list to tar via stdin rather than argv: the deployed footprint
+	// can be many files, which as an argument list would risk ARG_MAX. Use NUL
+	// delimiters (--null) so a filename containing a newline cannot corrupt the
+	// list — matching the shell-quoting safety the remote path already applies.
+	// Both GNU tar and bsdtar read NUL-separated names from "-" under --null.
+	args = append(args, "--null", "-T", "-")
 	cmd := exec.CommandContext(ctx, "tar", args...)
-	cmd.Stdin = strings.NewReader(strings.Join(existingPaths, "\n") + "\n")
+	cmd.Stdin = strings.NewReader(strings.Join(existingPaths, "\x00") + "\x00")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 

--- a/internal/reconcile/backup.go
+++ b/internal/reconcile/backup.go
@@ -160,8 +160,12 @@ func (d *DeployOps) Backup(ctx context.Context, backupDir string, paths []string
 		logger.Warn().Err(absErr).Str(log.FieldPath, backupDir).
 			Msg("Failed to resolve absolute backup path; self-exclusion skipped")
 	}
-	args = append(args, existingPaths...)
+	// Feed the path list to tar via stdin (-T -) rather than argv: the deployed
+	// footprint can be many files, which as an argument list would risk ARG_MAX.
+	// Both GNU tar and bsdtar read newline-separated names from "-".
+	args = append(args, "-T", "-")
 	cmd := exec.CommandContext(ctx, "tar", args...)
+	cmd.Stdin = strings.NewReader(strings.Join(existingPaths, "\n") + "\n")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 

--- a/internal/reconcile/backup_test.go
+++ b/internal/reconcile/backup_test.go
@@ -200,6 +200,36 @@ func TestCreateBackup_HonorsBackupTimeout(t *testing.T) {
 	}
 }
 
+// TestCreateBackup_RemotePathPropagatesFailure drives the remote branch of
+// createBackup: with local=false it selects RemoteAppdataPath and calls
+// BackupRemote, whose validateHost guard rejects the unresolved host and fails
+// fast (no SSH attempt). The non-timeout failure must propagate to the caller.
+func TestCreateBackup_RemotePathPropagatesFailure(t *testing.T) {
+	tmpDir := evalSymlinks(t, t.TempDir())
+	stagingDir := filepath.Join(tmpDir, "staging")
+	backupDir := filepath.Join(tmpDir, "backups")
+
+	// A staging footprint so backupFilesFromTargets enumerates a remote path.
+	require.NoError(t, os.MkdirAll(filepath.Join(stagingDir, "appdata", "svc"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(stagingDir, "appdata", "svc", "conf.yml"), []byte("config"), 0644))
+
+	cfg := &Config{
+		StagingDir:        stagingDir,
+		InfraSubDir:       ".",
+		BackupDir:         backupDir,
+		RemoteAppdataPath: "/mnt/appdata",
+		BackupsToKeep:     3,
+		// No TargetHost and nil secrets -> getTargetHost yields an unusable host
+		// that validateHost rejects, so BackupRemote fails before any ssh call.
+	}
+	r := NewReconciler(cfg)
+
+	err := r.createBackup(context.Background(), nil, false)
+	require.Error(t, err, "remote backup with an invalid host must propagate a failure")
+	assert.False(t, errors.Is(err, context.DeadlineExceeded),
+		"failure must be the host/ssh error, not a timeout, got: %v", err)
+}
+
 // TestExtractBackupArchive round-trips through the real Backup(): create an
 // archive, extract it, and confirm the backed-up file resolves under the
 // extracted root accounting for tar's leading-'/' stripping (#332/#335).

--- a/internal/reconcile/backup_test.go
+++ b/internal/reconcile/backup_test.go
@@ -230,6 +230,44 @@ func TestCreateBackup_RemotePathPropagatesFailure(t *testing.T) {
 		"failure must be the host/ssh error, not a timeout, got: %v", err)
 }
 
+// TestCreateBackup_DiscoveryFailureFallsBackToFullAppdata verifies that when
+// deploy-target discovery fails (here, a missing staging subtree), the backup
+// falls back to the full appdata path rather than producing a no-op archive —
+// preserving rollback protection exactly when the footprint is unknown.
+func TestCreateBackup_DiscoveryFailureFallsBackToFullAppdata(t *testing.T) {
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not installed")
+	}
+
+	tmpDir := evalSymlinks(t, t.TempDir())
+	appdataDir := filepath.Join(tmpDir, "appdata")
+	backupDir := filepath.Join(tmpDir, "backups")
+	require.NoError(t, os.MkdirAll(appdataDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(appdataDir, "live.conf"), []byte("existing"), 0644))
+
+	cfg := &Config{
+		// InfraSubDir points at a path that does not exist under StagingDir, so
+		// discoverDeployTargets fails and the full-appdata fallback engages.
+		StagingDir:       tmpDir,
+		InfraSubDir:      "missing-staging",
+		BackupDir:        backupDir,
+		LocalAppdataPath: appdataDir,
+		BackupsToKeep:    3,
+	}
+	r := NewReconciler(cfg)
+
+	require.NoError(t, r.createBackup(context.Background(), nil, true))
+
+	members := listArchiveMembers(t, filepath.Join(r.lastBackupPath, "configs.tar.gz"))
+	var found bool
+	for _, m := range members {
+		if strings.Contains(m, "live.conf") {
+			found = true
+		}
+	}
+	assert.True(t, found, "discovery-failure fallback must back up the full appdata path, not a no-op")
+}
+
 // TestExtractBackupArchive round-trips through the real Backup(): create an
 // archive, extract it, and confirm the backed-up file resolves under the
 // extracted root accounting for tar's leading-'/' stripping (#332/#335).

--- a/internal/reconcile/backup_test.go
+++ b/internal/reconcile/backup_test.go
@@ -77,6 +77,50 @@ func TestBackup_ExcludesBackupDestination(t *testing.T) {
 	assert.True(t, foundService, "archive should still contain the real service config")
 }
 
+// TestBackup_ScopesToDeployedFiles verifies the end-to-end fix for bosun-5qx:
+// the backup footprint enumerated from the staging source (backupFilesFromTargets)
+// archives only bosun-managed config, so large runtime data co-located in the
+// same appdata directory — the cause of the 5m timeout — never enters the archive.
+func TestBackup_ScopesToDeployedFiles(t *testing.T) {
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not installed")
+	}
+
+	// Staging footprint: only the rendered config bosun deploys.
+	staging := evalSymlinks(t, t.TempDir())
+	require.NoError(t, os.MkdirAll(filepath.Join(staging, "appdata/svc"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(staging, "appdata/svc/config.yml"), []byte("managed"), 0644))
+
+	// Destination appdata: the managed config PLUS unrelated runtime data that is
+	// NOT part of the staging footprint (media/db/cache stand-in).
+	appdata := evalSymlinks(t, t.TempDir())
+	require.NoError(t, os.MkdirAll(filepath.Join(appdata, "svc/data"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(appdata, "svc/config.yml"), []byte("managed"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(appdata, "svc/data/runtime.bin"), make([]byte, 1<<20), 0644))
+
+	targets := []DeployTarget{{RelPath: "appdata/svc", TargetPath: "svc", IsDir: true}}
+	paths, err := backupFilesFromTargets(staging, targets, appdata)
+	require.NoError(t, err)
+	require.Equal(t, []string{filepath.Join(appdata, "svc/config.yml")}, paths,
+		"enumeration must scope to the staging footprint, excluding runtime data")
+
+	backupDir := evalSymlinks(t, t.TempDir())
+	d := NewDeployOps(false, "")
+	backupName, err := d.Backup(context.Background(), backupDir, paths)
+	require.NoError(t, err)
+
+	members := listArchiveMembers(t, filepath.Join(backupDir, backupName, "configs.tar.gz"))
+	var foundConfig bool
+	for _, m := range members {
+		assert.NotContains(t, m, "runtime.bin",
+			"runtime data must not enter the archive (member: %s)", m)
+		if strings.Contains(m, "svc/config.yml") {
+			foundConfig = true
+		}
+	}
+	assert.True(t, foundConfig, "archive should contain the managed config file")
+}
+
 // TestVerifyBackup_HonorsCancelledContext verifies that backup verification runs
 // under the caller's context, so a cancelled/deadline-exceeded context aborts the
 // `tar -tzf` listing rather than blocking indefinitely on a growing archive (#319).
@@ -120,9 +164,12 @@ func TestCreateBackup_HonorsBackupTimeout(t *testing.T) {
 	// Backup destination nested under appdata — the realistic #319 layout.
 	backupDir := filepath.Join(appdataDir, "bosun", "backups")
 
-	// Staging target so discoverDeployTargets finds the "bosun" service...
+	// Staging footprint defines what gets backed up: a real file in the staging
+	// source so backupFilesFromTargets enumerates it (the "bosun" service)...
 	require.NoError(t, os.MkdirAll(filepath.Join(stagingDir, "appdata", "bosun"), 0755))
-	// ...and a real source path so Backup actually invokes tar (non-empty work).
+	require.NoError(t, os.WriteFile(filepath.Join(stagingDir, "appdata", "bosun", "conf.yml"), []byte("config"), 0644))
+	// ...and the matching destination on disk so Backup keeps it and invokes tar
+	// (non-empty work, so the expired deadline surfaces instead of an early return).
 	require.NoError(t, os.MkdirAll(filepath.Join(appdataDir, "bosun"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(appdataDir, "bosun", "conf.yml"), []byte("config"), 0644))
 

--- a/internal/reconcile/discovery.go
+++ b/internal/reconcile/discovery.go
@@ -1,6 +1,7 @@
 package reconcile
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -131,4 +132,56 @@ func filterExclude(targets []DeployTarget, patterns []string) []DeployTarget {
 		}
 	}
 	return result
+}
+
+// backupFilesFromTargets enumerates the destination files that make up each
+// target's deployed footprint — the files bosun renders into staging and syncs
+// to appdata — so the pre-deploy backup captures only managed config, not the
+// unrelated runtime data (media, databases, caches) co-located in the same
+// appdata directory. Backing up whole target directories let the archive grow
+// without bound and time out (bosun-5qx / GH#330 secondary).
+//
+// For each target it walks the STAGING source (small, rendered output) and maps
+// every regular file onto its appdata destination path under appdataBase. A
+// file target maps directly to its destination. Symlinks and directories are
+// skipped via IsRegular() (Lstat semantics), matching the copy path — which
+// never deploys symlinks — and verifyDeployTarget. Destinations that do not yet
+// exist on disk (a brand-new file this deploy adds) are left for Backup() to
+// filter out; there is nothing to back up for them.
+//
+// Returns the destination file paths and the first walk error encountered.
+// Callers treat the error as non-fatal and back up whatever was enumerated.
+func backupFilesFromTargets(stagingSubDir string, targets []DeployTarget, appdataBase string) ([]string, error) {
+	var (
+		files    []string
+		firstErr error
+	)
+	for _, t := range targets {
+		dst := filepath.Join(appdataBase, t.TargetPath)
+		if !t.IsDir {
+			files = append(files, dst)
+			continue
+		}
+		src := filepath.Join(stagingSubDir, t.RelPath)
+		walkErr := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			// IsRegular() is false for directories and symlinks alike, matching
+			// the copy path's symlink skip and verifyDeployTarget.
+			if !d.Type().IsRegular() {
+				return nil
+			}
+			rel, relErr := filepath.Rel(src, path)
+			if relErr != nil {
+				return relErr
+			}
+			files = append(files, filepath.Join(dst, rel))
+			return nil
+		})
+		if walkErr != nil && firstErr == nil {
+			firstErr = walkErr
+		}
+	}
+	return files, firstErr
 }

--- a/internal/reconcile/discovery_test.go
+++ b/internal/reconcile/discovery_test.go
@@ -183,24 +183,68 @@ func TestHasTarget(t *testing.T) {
 	assert.False(t, hasTarget(targets, ""))
 }
 
-func TestBackupPathsFromTargets(t *testing.T) {
+// TestBackupFilesFromTargets asserts the backup footprint is the set of regular
+// files bosun renders into staging, mapped onto appdata destinations — not the
+// whole target directories. Runtime data co-located in appdata is never in
+// staging, so it cannot leak into the list (bosun-5qx).
+func TestBackupFilesFromTargets(t *testing.T) {
+	staging := t.TempDir()
+	mkdirs(t, staging, "appdata/traefik/conf", "compose")
+	writeFile(t, filepath.Join(staging, "appdata/traefik/traefik.yml"), "root")
+	writeFile(t, filepath.Join(staging, "appdata/traefik/conf/dynamic.yml"), "nested")
+	writeFile(t, filepath.Join(staging, "compose/docker-compose.yml"), "stack")
+
 	targets := []DeployTarget{
 		{RelPath: "appdata/traefik", TargetPath: "traefik", IsDir: true},
-		{RelPath: "appdata/authelia", TargetPath: "authelia", IsDir: true},
-		{RelPath: "compose", TargetPath: "compose", IsDir: true}, // now included for per-file rollback
+		{RelPath: "compose", TargetPath: "compose", IsDir: true},
 	}
 
-	paths := backupPathsFromTargets(targets, "/mnt/appdata")
-	assert.Equal(t, []string{
-		"/mnt/appdata/traefik",
-		"/mnt/appdata/authelia",
-		"/mnt/appdata/compose",
+	paths, err := backupFilesFromTargets(staging, targets, "/mnt/appdata")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"/mnt/appdata/traefik/traefik.yml",
+		"/mnt/appdata/traefik/conf/dynamic.yml",
+		"/mnt/appdata/compose/docker-compose.yml",
 	}, paths)
 }
 
-func TestBackupPathsFromTargets_Empty(t *testing.T) {
-	paths := backupPathsFromTargets(nil, "/mnt/appdata")
+// TestBackupFilesFromTargets_SkipsSymlinks confirms symlinks in staging are not
+// enumerated, matching the deploy path which never copies them.
+func TestBackupFilesFromTargets_SkipsSymlinks(t *testing.T) {
+	staging := t.TempDir()
+	mkdirs(t, staging, "appdata/svc")
+	writeFile(t, filepath.Join(staging, "appdata/svc/config.yml"), "real")
+	require.NoError(t, os.Symlink("config.yml", filepath.Join(staging, "appdata/svc/link.yml")))
+
+	targets := []DeployTarget{{RelPath: "appdata/svc", TargetPath: "svc", IsDir: true}}
+	paths, err := backupFilesFromTargets(staging, targets, "/mnt/appdata")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/mnt/appdata/svc/config.yml"}, paths)
+}
+
+// TestBackupFilesFromTargets_FileTarget maps a single-file target directly to
+// its destination path.
+func TestBackupFilesFromTargets_FileTarget(t *testing.T) {
+	staging := t.TempDir()
+	writeFile(t, filepath.Join(staging, ".env"), "K=V")
+
+	targets := []DeployTarget{{RelPath: ".env", TargetPath: ".env", IsDir: false}}
+	paths, err := backupFilesFromTargets(staging, targets, "/mnt/appdata")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/mnt/appdata/.env"}, paths)
+}
+
+func TestBackupFilesFromTargets_Empty(t *testing.T) {
+	paths, err := backupFilesFromTargets(t.TempDir(), nil, "/mnt/appdata")
+	require.NoError(t, err)
 	assert.Nil(t, paths)
+}
+
+// writeFile creates a file with the given content, making parent dirs as needed.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
 }
 
 // mkdirs creates nested directory structures under base.

--- a/internal/reconcile/discovery_test.go
+++ b/internal/reconcile/discovery_test.go
@@ -240,6 +240,29 @@ func TestBackupFilesFromTargets_Empty(t *testing.T) {
 	assert.Nil(t, paths)
 }
 
+// TestBackupFilesFromTargets_WalkError confirms an unreadable subtree surfaces as
+// a returned error (rather than being silently dropped), while files enumerated
+// before the error are still returned for a best-effort backup. The readable file
+// is named to sort before the locked dir so WalkDir visits it first.
+func TestBackupFilesFromTargets_WalkError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod 0000 does not deny root; skipping permission-based fault injection")
+	}
+	staging := t.TempDir()
+	mkdirs(t, staging, "appdata/svc/locked")
+	writeFile(t, filepath.Join(staging, "appdata/svc/aaa.yml"), "ok")
+	locked := filepath.Join(staging, "appdata/svc/locked")
+	require.NoError(t, os.Chmod(locked, 0000))
+	// Restore perms before t.TempDir's RemoveAll cleanup, which would otherwise fail.
+	t.Cleanup(func() { _ = os.Chmod(locked, 0755) })
+
+	targets := []DeployTarget{{RelPath: "appdata/svc", TargetPath: "svc", IsDir: true}}
+	paths, err := backupFilesFromTargets(staging, targets, "/mnt/appdata")
+	require.Error(t, err, "an unreadable subtree must surface as a walk error")
+	assert.Contains(t, paths, "/mnt/appdata/svc/aaa.yml",
+		"files enumerated before the error are still returned for best-effort backup")
+}
+
 // writeFile creates a file with the given content, making parent dirs as needed.
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1167,10 +1167,6 @@ func (r *Reconciler) createBackup(ctx context.Context, secrets map[string]any, l
 	// Discover targets from staging to know what to back up.
 	stagingSubDir := filepath.Join(r.config.StagingDir, r.config.InfraSubDir)
 	targets, err := discoverDeployTargets(stagingSubDir, r.config.DeploySyncPaths.Value, r.config.DeploySyncExclude.Value)
-	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to discover deploy targets for backup, proceeding with full backup")
-		// Don't fail the entire backup — use nil targets to back up the full path
-	}
 
 	var backupName string
 
@@ -1182,9 +1178,21 @@ func (r *Reconciler) createBackup(ctx context.Context, secrets map[string]any, l
 	if !local {
 		appdataBase = r.config.RemoteAppdataPath
 	}
-	paths, ferr := backupFilesFromTargets(stagingSubDir, targets, appdataBase)
-	if ferr != nil {
-		logger.Warn().Err(ferr).Msg("Failed to enumerate full backup footprint; backing up the files discovered so far")
+
+	var paths []string
+	if err != nil {
+		// Discovery failed, so the rendered footprint is unknown. Fall back to the
+		// full appdata path for rollback protection rather than a no-op backup; the
+		// BackupTimeout above bounds it so a large tree cannot wedge the deploy.
+		logger.Warn().Err(err).Str(log.FieldPath, appdataBase).
+			Msg("Failed to discover deploy targets for backup; falling back to full appdata backup")
+		paths = []string{appdataBase}
+	} else {
+		var ferr error
+		paths, ferr = backupFilesFromTargets(stagingSubDir, targets, appdataBase)
+		if ferr != nil {
+			logger.Warn().Err(ferr).Msg("Failed to enumerate full backup footprint; backing up the files discovered so far")
+		}
 	}
 
 	if local {

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1174,13 +1174,24 @@ func (r *Reconciler) createBackup(ctx context.Context, secrets map[string]any, l
 
 	var backupName string
 
+	// Back up only the deployed config footprint (the files bosun renders into
+	// staging), not whole appdata target directories — those co-locate large
+	// runtime data (media, databases, caches) that made the archive grow without
+	// bound and time out (bosun-5qx).
+	appdataBase := r.config.LocalAppdataPath
+	if !local {
+		appdataBase = r.config.RemoteAppdataPath
+	}
+	paths, ferr := backupFilesFromTargets(stagingSubDir, targets, appdataBase)
+	if ferr != nil {
+		logger.Warn().Err(ferr).Msg("Failed to enumerate full backup footprint; backing up the files discovered so far")
+	}
+
 	if local {
-		paths := backupPathsFromTargets(targets, r.config.LocalAppdataPath)
 		logger.Debug().Int("path_count", len(paths)).Msg("Creating local backup")
 		backupName, err = r.deploy.Backup(ctx, r.config.BackupDir, paths)
 	} else {
 		host := r.getTargetHost(secrets)
-		paths := backupPathsFromTargets(targets, r.config.RemoteAppdataPath)
 		logger.Debug().Str(log.FieldTarget, host).Int("path_count", len(paths)).Msg("Creating remote backup")
 		backupName, err = r.deploy.BackupRemote(ctx, host, r.config.BackupDir, paths)
 	}
@@ -1208,16 +1219,6 @@ func (r *Reconciler) createBackup(ctx context.Context, secrets map[string]any, l
 
 	ui.Success("Backup saved: %s", backupName)
 	return nil
-}
-
-// backupPathsFromTargets derives backup paths from discovered deploy targets.
-// All targets including compose are backed up so per-file rollback has files to restore from.
-func backupPathsFromTargets(targets []DeployTarget, appdataBase string) []string {
-	var paths []string
-	for _, t := range targets {
-		paths = append(paths, filepath.Join(appdataBase, t.TargetPath))
-	}
-	return paths
 }
 
 // ErrAppdataInaccessible is returned when LocalAppdataPath is configured but

--- a/skills/onboard/resources/gitops.md
+++ b/skills/onboard/resources/gitops.md
@@ -69,11 +69,19 @@ Per-file write decisions are observable at `Debug` level: `CopyDirIfChanged` and
 
 ### Configuration Backup (stage 7)
 
-Before deploying new configs, bosun tars each deploy target's appdata into a
-timestamped `backup-YYYYMMDD-HHMMSS/configs.tar.gz` under `BackupDir`, verifies
+Before deploying new configs, bosun tars the **deployed config footprint** —
+the files it renders into staging, mapped onto their appdata destinations — into
+a timestamped `backup-YYYYMMDD-HHMMSS/configs.tar.gz` under `BackupDir`, verifies
 it by listing the archive, and prunes to the most recent `BackupsToKeep`
-(default 5). Two guards keep the backup from wedging the reconcile (GH#319):
+(default 5). Three guards keep the backup from wedging the reconcile (GH#319,
+bosun-5qx):
 
+- **Footprint scoping.** The backup captures only the files bosun manages (its
+  rendered staging footprint), not whole appdata target directories — those
+  co-locate large runtime data (media, databases, caches) that made the archive
+  grow without bound and burn the full timeout every reconcile. Symlinks are
+  skipped, matching the deploy path. The path list is fed to `tar` via stdin
+  (`-T -`) so a large footprint cannot overflow the argument list.
 - **Self-exclusion.** Bosun is itself a deploy target, and `BackupDir`
   (default `/app/backups` → host `/mnt/appdata/bosun/backups`) lives *inside* a
   backed-up path. The creation tar passes `--exclude` for the backup


### PR DESCRIPTION
## Summary

The pre-deploy backup tarred **whole appdata target directories**, sweeping in large runtime data (media, databases, caches) co-located with bosun's config. On a real homelab the archive never finished within `BACKUP_TIMEOUT` (5m), so every reconcile burned the full timeout then reported the partial archive as "corrupted" (**bosun-5qx**, GH#330 secondary). #319 bounded the timeout + made it non-fatal but never addressed *why* the backup was unbounded.

## Fix

Scope the backup to the **deployed footprint**:

- New `backupFilesFromTargets` walks the staging source (small, rendered output), maps each regular file onto its appdata destination, and backs up only those. Runtime data is never in staging → it cannot enter the archive.
- Symlinks/dirs skipped via `IsRegular()` (Lstat semantics), matching the deploy copy path and `verifyDeployTarget`.
- `Backup()` now feeds the path list to `tar` via stdin (`-T -`) instead of argv, so a large footprint can't overflow `ARG_MAX`.
- Removed the now-unused `backupPathsFromTargets` (whole-dir mapping).

Archive member layout is unchanged (tar still strips leading `/`), so `extractBackupArchive`/`resolveBackupFile` rollback resolution is unaffected.

## Spec stance

Conforms to the existing `Configuration Backup` requirement (`reconcile/spec.md`: *"backup of existing **configuration files**"*) — this narrows over-broad collection to match spec intent, so **no OpenSpec delta** is required.

## Tests

- `TestBackup_ScopesToDeployedFiles` — end-to-end: a 1 MB runtime file co-located in appdata is **excluded** from the archive; the managed config is **included**.
- `backupFilesFromTargets` unit tests: dir-walk mapping, symlink skip, file target, empty.
- Updated `TestCreateBackup_HonorsBackupTimeout` fixture to seed the staging footprint (the new source of truth).

Verification: `go build ./...`, `go vet`, `gofmt` clean; `go test ./internal/reconcile/` green except the Docker-gated full-reconcile subtest, which fails identically on a clean tree (no local Docker daemon).

## Follow-up

- **GH#374** — evaluate whether a configurable `BackupExclude` is still warranted now that the default is footprint-scoped.

Resolves **bosun-5qx**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)