### PR TITLE
docs: correct daemon API reference and document breaker/ports/migrate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,8 +326,8 @@ All bosun-specific env vars use the `BOSUN_` prefix. Legacy unprefixed vars (`RE
 | `BOSUN_REPO_BRANCH` | daemon, reconcile | Branch to track (default: `main`) |
 | `BOSUN_POLL_INTERVAL` | daemon | Polling interval in seconds (default: `3600`) |
 | `BOSUN_SOCKET_PATH` | daemon | Unix socket path (default: `/var/run/bosun.sock`) |
-| `BOSUN_ENABLE_TCP` | daemon | Enable TCP API (`true`/`false`) |
-| `BOSUN_TCP_ADDR` | daemon | TCP listen address (default: `:8080`) |
+| `BOSUN_ENABLE_TCP` | daemon | Enable TCP API (`true`/`false`; default: `false`) |
+| `BOSUN_TCP_ADDR` | daemon | TCP listen address (default: `127.0.0.1:9090`) |
 | `BOSUN_BEARER_TOKEN` | daemon, trigger | Bearer token for TCP auth |
 | `BOSUN_DISABLE_HTTP` | daemon | Disable HTTP webhook server |
 | `BOSUN_SECRETS_FILE` | daemon, render | SOPS secrets file path |

--- a/docs/architecture/daemon-split.md
+++ b/docs/architecture/daemon-split.md
@@ -17,9 +17,10 @@ Split bosun into two components for resilience and flexibility:
 > - **Optional TCP API on `127.0.0.1:9090`** — disabled by default; enable with
 >   `BOSUN_ENABLE_TCP=true` and a required `BOSUN_BEARER_TOKEN`.
 > - Reconcile lock file: `/var/run/bosun/reconcile.lock`.
-> - **Webhook provider split:** the daemon handles GitHub and the generic HMAC
->   endpoint directly; GitLab, Gitea, and Bitbucket are normalized by the
->   separate `bosun webhook` receiver, which forwards to the daemon.
+> - **Webhook provider split:** the daemon natively parses GitHub plus a generic
+>   HMAC endpoint (`/webhook`). The optional `bosun webhook` receiver normalizes
+>   any provider and forwards to the daemon's trigger endpoint — its reason to
+>   exist is GitLab/Gitea/Bitbucket, which the daemon has no native parser for.
 >
 > There is **no `BOSUN_TRIGGER_PORT`** env var and **no port `9999`** in the
 > codebase — the `8080` references below are the real HTTP port.

--- a/docs/architecture/daemon-split.md
+++ b/docs/architecture/daemon-split.md
@@ -7,6 +7,23 @@ Split bosun into two components for resilience and flexibility:
 1. **Host Daemon** (`bosun daemon`) - Runs on Unraid host, survives array stop/start
 2. **Webhook Container** (`bosun-webhook`) - Optional, disposable, handles external triggers
 
+> **Implementation status.** This is the original split-architecture *design
+> proposal*; some details below were never implemented as written. The shipped
+> daemon's actual interfaces:
+>
+> - **Unix socket `/var/run/bosun.sock`** — primary control API (default).
+> - **HTTP webhooks on `:8080`** — GitHub (`/webhook/github`) plus a generic
+>   HMAC endpoint (`/webhook`), and `/health` / `/ready` probes.
+> - **Optional TCP API on `127.0.0.1:9090`** — disabled by default; enable with
+>   `BOSUN_ENABLE_TCP=true` and a required `BOSUN_BEARER_TOKEN`.
+> - Reconcile lock file: `/var/run/bosun/reconcile.lock`.
+> - **Webhook provider split:** the daemon handles GitHub and the generic HMAC
+>   endpoint directly; GitLab, Gitea, and Bitbucket are normalized by the
+>   separate `bosun webhook` receiver, which forwards to the daemon.
+>
+> There is **no `BOSUN_TRIGGER_PORT`** env var and **no port `9999`** in the
+> codebase — the `8080` references below are the real HTTP port.
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                         UNRAID HOST                              │
@@ -23,7 +40,7 @@ Split bosun into two components for resilience and flexibility:
 │  │  • Snapshot before deploy, rollback on failure              │ │
 │  │  • Discord/SendGrid/Twilio alerting                         │ │
 │  │                                                             │ │
-│  │  HTTP API (localhost:9999):                                 │ │
+│  │  HTTP API (localhost:8080):                                 │ │
 │  │    POST /trigger      - Trigger reconcile                   │ │
 │  │    GET  /health       - Health check                        │ │
 │  │    GET  /status       - Current state, last reconcile       │ │
@@ -39,7 +56,7 @@ Split bosun into two components for resilience and flexibility:
 │  │  • Receives GitHub webhook POST                             │ │
 │  │  • HMAC-SHA256 signature validation                         │ │
 │  │  • Filters by branch (only trigger on tracked branch)       │ │
-│  │  • Calls daemon at host.docker.internal:9999/trigger        │ │
+│  │  • Calls daemon at host.docker.internal:8080/trigger        │ │
 │  │                                                             │ │
 │  │  Exposed via: Tailscale Funnel / Cloudflare Tunnel          │ │
 │  └─────────────────────────────────────────────────────────────┘ │
@@ -85,7 +102,6 @@ Split bosun into two components for resilience and flexibility:
 BOSUN_REPO_URL=git@github.com:user/infrastructure.git
 BOSUN_REPO_BRANCH=main
 BOSUN_POLL_INTERVAL=3600
-BOSUN_TRIGGER_PORT=9999
 SOPS_AGE_KEY_FILE=/boot/config/plugins/bosun/age-key.txt
 DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
 ```
@@ -120,7 +136,7 @@ services:
     restart: unless-stopped
     environment:
       WEBHOOK_SECRET: ${WEBHOOK_SECRET}
-      DAEMON_URL: http://host.docker.internal:9999
+      DAEMON_URL: http://host.docker.internal:8080
       TRACKED_BRANCH: main
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -155,14 +171,14 @@ services:
 extra_hosts:
   - "host.docker.internal:host-gateway"
 environment:
-  DAEMON_URL: http://host.docker.internal:9999
+  DAEMON_URL: http://host.docker.internal:8080
 ```
 Requires Docker 20.10+
 
 **Option 2: Bridge Gateway IP**
 ```yaml
 environment:
-  DAEMON_URL: http://172.17.0.1:9999
+  DAEMON_URL: http://172.17.0.1:8080
 ```
 Works on older Docker, but IP may vary.
 
@@ -170,7 +186,7 @@ Works on older Docker, but IP may vary.
 ```yaml
 network_mode: host
 environment:
-  DAEMON_URL: http://localhost:9999
+  DAEMON_URL: http://localhost:8080
 ```
 Loses network isolation.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -405,7 +405,7 @@ Validates:
 ### breaker
 
 View and manage the deploy circuit breaker, which stops retrying after 3
-consecutive deploy failures.
+consecutive deploy failures on the same commit. A new commit resets the counter.
 
 ```bash
 bosun breaker status           # Show breaker state (failure count, open/closed)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -239,6 +239,25 @@ bosun create worker myworker
 
 Creates a service manifest in `manifest/services/<name>.yml`.
 
+### migrate
+
+Migrate manifests to the current schema, or convert legacy provision-based
+manifests to the Helm-aligned chart format. Both subcommands default to a
+dry-run.
+
+```bash
+bosun migrate version          # Add apiVersion/kind fields (dry-run)
+bosun migrate version --write  # Apply the migration
+bosun migrate helm             # Convert legacy manifests to Helm-aligned format
+bosun migrate helm --force     # Overwrite existing charts
+```
+
+| Subcommand | Flag | Description |
+|------------|------|-------------|
+| `version` | `-w`, `--write` | Write changes (default is dry-run) |
+| `version` | `--provisions` / `--services` / `--stacks` | Override directories to scan |
+| `helm` | `--force` | Overwrite existing charts |
+
 ## Radio Commands
 
 Communication and connectivity commands.
@@ -382,6 +401,38 @@ Validates:
 - Stack manifests are valid
 - Dependencies are correct
 - No port conflicts
+
+### breaker
+
+View and manage the deploy circuit breaker, which stops retrying after 3
+consecutive deploy failures.
+
+```bash
+bosun breaker status           # Show breaker state (failure count, open/closed)
+bosun breaker reset            # Clear the failure counter to allow retries
+bosun breaker reset --target=nas   # Reset for a specific target
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--state-dir` | `/var/lib/bosun` | Deploy state directory |
+| `-t`, `--target` | | Named deployment target (from `targets:` in `bosun.yaml`) |
+
+### ports
+
+List host-port allocations across all stacks (from rendered compose files) and
+detect conflicts.
+
+```bash
+bosun ports                    # All host-port allocations + conflict detection
+bosun ports --service traefik  # Ports for a specific service
+bosun ports --free 8000-9000   # Available ports in a range
+```
+
+| Flag | Description |
+|------|-------------|
+| `-s`, `--service` | Show ports for a specific service |
+| `--free` | Show available ports in a range (e.g. `8000-9000`) |
 
 ## Upgrade Commands
 

--- a/skills/onboard/resources/commands.md
+++ b/skills/onboard/resources/commands.md
@@ -204,6 +204,25 @@ bosun chart show <name>        # Detailed chart info (templates, deps, version)
 bosun template list            # List available templates (alias: templates)
 ```
 
+### `bosun migrate`
+
+Migrate manifests to the current schema or convert legacy provision-based
+manifests to the Helm-aligned chart format. Both subcommands default to a
+dry-run; pass the write flag to apply changes.
+
+```bash
+bosun migrate version          # Add apiVersion/kind fields (dry-run)
+bosun migrate version --write  # Apply the apiVersion/kind migration
+bosun migrate helm             # Convert legacy manifests to Helm-aligned format
+bosun migrate helm --force     # Overwrite existing charts
+```
+
+| Subcommand | Flag | Default | Description |
+|------------|------|---------|-------------|
+| `version` | `-w`, `--write` | `false` | Write changes to files (default is dry-run) |
+| `version` | `--provisions` / `--services` / `--stacks` | | Override the directories to scan |
+| `helm` | `--force` | `false` | Overwrite existing charts |
+
 ---
 
 ## GitOps Commands
@@ -364,6 +383,38 @@ bosun validate --full                  # Include full dry-run reconciliation
 | `--full` | Run full dry-run reconciliation |
 | `--socket` | Path to daemon socket |
 | `-t`, `--timeout` | Timeout in seconds (default: 30) |
+
+### `bosun breaker`
+
+View and manage the deploy circuit breaker, which stops retrying after 3
+consecutive deploy failures.
+
+```bash
+bosun breaker status           # Show circuit breaker state (failure count, open/closed)
+bosun breaker reset            # Clear the failure counter to allow retries
+bosun breaker reset --target=nas   # Reset the breaker for a specific target
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--state-dir` | `/var/lib/bosun` | Deploy state directory |
+| `-t`, `--target` | | Named deployment target (from `targets:` in `bosun.yaml`) |
+
+### `bosun ports`
+
+List host-port allocations across all stacks (from rendered compose files) and
+detect conflicts.
+
+```bash
+bosun ports                    # All host-port allocations + conflict detection
+bosun ports --service traefik  # Ports for a specific service
+bosun ports --free 8000-9000   # Available ports in a range
+```
+
+| Flag | Description |
+|------|-------------|
+| `-s`, `--service` | Show ports for a specific service |
+| `--free` | Show available ports in a range (e.g. `8000-9000`) |
 
 ---
 

--- a/skills/onboard/resources/commands.md
+++ b/skills/onboard/resources/commands.md
@@ -387,7 +387,7 @@ bosun validate --full                  # Include full dry-run reconciliation
 ### `bosun breaker`
 
 View and manage the deploy circuit breaker, which stops retrying after 3
-consecutive deploy failures.
+consecutive deploy failures on the same commit. A new commit resets the counter.
 
 ```bash
 bosun breaker status           # Show circuit breaker state (failure count, open/closed)


### PR DESCRIPTION
## Summary

Salvages the accurate, **verifiable** half of stale PR #362's docs overhaul (**bosun-vam**). Every claim was checked against current source. Doc-only.

### Daemon API reference (`docs/architecture/daemon-split.md`)
This was a historical *design proposal* referencing a phantom `9999` port / `BOSUN_TRIGGER_PORT` env var that **never shipped** (neither appears anywhere in `internal/` or `cmd/`).
- Added an **implementation-status banner** with the real interfaces: Unix socket `/var/run/bosun.sock` (primary), HTTP `:8080` (GitHub + generic HMAC webhooks, `/health`/`/ready`), optional TCP `127.0.0.1:9090` (`BOSUN_ENABLE_TCP` + `BOSUN_BEARER_TOKEN`), lock file `/var/run/bosun/reconcile.lock`, and the daemon-vs-standalone webhook provider split.
- Removed the phantom `BOSUN_TRIGGER_PORT=9999` from the copy-pasteable env example; corrected all `:9999` → `:8080` (equal-length swap, ASCII alignment preserved).

### Env table (`AGENTS.md`)
- `BOSUN_TCP_ADDR` default `:8080` → **`127.0.0.1:9090`** (matches `daemon.go`); noted TCP is disabled by default.

### Command parity (`docs/commands.md` + `skills/onboard/resources/commands.md`)
Documented three commands present in `internal/cmd/` but missing from the docs, **flags verified against source**:
- `breaker` (`status`/`reset`, `--state-dir`, `-t/--target`)
- `ports` (`-s/--service`, `--free`) — note: a **top-level** command, not a diagnostics subcommand (the salvage source guessed wrong)
- `migrate` (`version`/`helm`, `-w/--write`, `--force`, dir overrides)

## Split out to bosun-9lb

The **diagram refresh** (reconcile-pipeline `LR`→`TD`, new `locking-singleflight`) is deferred: the README diagrams are tool-rendered, and re-running the renderer with the *pinned* `beautiful-mermaid@1.1.3` churns two **unrelated** diagrams (the committed README is stale vs the pinned tool). bosun-9lb tracks the diagrams + that renderer-drift decision + the ADR-doc `9999` cleanup (`decisions.md`, `bosun-architecture-review.md`).

## Verification

`grep -rn '9999|BOSUN_TRIGGER_PORT' docs/architecture/daemon-split.md AGENTS.md` → only the banner line that explains they don't exist. Command flags cross-checked against `internal/cmd/{breaker,ports,migrate}.go`.

Resolves **bosun-vam** (diagrams tracked in **bosun-9lb**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)